### PR TITLE
Database reset functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ The cactus runner application uses the following environment variables,
 | APP_PORT | 8000 | The port the cactus runner application listens on. |
 | KICKOFF_FILE | `/shared/.kickoff` | The location to create the kickoff file, which triggers kubernetes to launch the envoy service |
 | ENVOY_ENV_FILE | `/shared/envoy.env` | The location to write the test-specific envoy environment variables. |
-| DEV_AGGREGATOR_PREREGISTERED | "false" | If True ("true", "1", "t") the aggregator is not registered when a test procedure is started. Intended for testing purposes only. |
-| DEV_SKIP_DB_PRECONDITIONS | "false" | If True ("true", "1", "t") the database preconditions are not applied. Intended for dev purposes only. |
 | DEV_SKIP_AUTHORIZATION_CHECK | "false" | If True ("true", "1", "t") no check is made that the forwarded certificate is valid. Intended for dev purposes only. |
 
 > NOTE:

--- a/src/cactus_runner/app/env.py
+++ b/src/cactus_runner/app/env.py
@@ -22,11 +22,5 @@ APP_PORT = int(os.getenv("APP_PORT", DEFAULT_APP_PORT))
 # MOUNT_POINT is the base path for all endpoints
 MOUNT_POINT = "/"
 
-# If true skips registering an aggregator at beginning of test procedure
-DEV_AGGREGATOR_PREREGISTERED = os.getenv("DEV_AGGREGATOR_PREREGISTERED", "false").lower() in ["true", "1", "t"]
-
-# If true skips applying database preconditions at beginning of test procedure
-DEV_SKIP_DB_PRECONDITIONS = os.getenv("DEV_SKIP_DB_PRECONDITIONS", "false").lower() in ["true", "1", "t"]
-
 # If true skips verifying the forwarded certificate in requests
 DEV_SKIP_AUTHORIZATION_CHECK = os.getenv("DEV_SKIP_AUTHORIZATION_CHECK", "false").lower() in ["true", "1", "t"]

--- a/src/cactus_runner/app/handler.py
+++ b/src/cactus_runner/app/handler.py
@@ -13,9 +13,7 @@ from envoy.server.crud.common import convert_lfdi_to_sfdi
 from cactus_runner.app import action, auth, event, finalize, precondition, status
 from cactus_runner.app.database import begin_session
 from cactus_runner.app.env import (
-    DEV_AGGREGATOR_PREREGISTERED,
     DEV_SKIP_AUTHORIZATION_CHECK,
-    DEV_SKIP_DB_PRECONDITIONS,
     SERVER_URL,
 )
 from cactus_runner.app.shared import (
@@ -47,18 +45,13 @@ async def init_handler(request: web.Request):
 
     The following initialization steps are performed:
 
-    1. Register the aggregator (along with its certificate)
-    2. Apply database preconditions
-    3. Trigger the envoy server to start with the correction configuration.
+    1. All tables in the database are truncated
+    2. Register the aggregator (along with its certificate)
+    3. Apply database preconditions
+    4. Trigger the envoy server to start with the correction configuration.
 
-    If the aggregator is already present (along with its certificate) in the utility
-    servers database, registering the aggregator (step 1) can be bypassed by setting
-    the environment variable 'DEV_AGGREGATOR_PREREGISTERED'.
 
-    To skip the database preconditions (step 2), the environment variable
-    'DEV_SKIP_DB_PRECONDITIONS' can be set.
-
-    Triggering the startup of the envoy server (step 3) is achieved by writing a '.env' file
+    Triggering the startup of the envoy server (step 4) is achieved by writing a '.env' file
     containing the envoy server configuration parameters then writing an empty kickoff file
     which is recognised by the container management system and results in the envoy server starting.
     The full paths of these two files is set through the ENVOY_ENV_FILE and KICKSTART_FILE environment variables.
@@ -109,10 +102,7 @@ async def init_handler(request: web.Request):
 
     # Get the lfdi of the aggregator to register
     aggregator_lfdi = LFDIAuthDepends.generate_lfdi_from_pem(aggregator_certificate)
-    if not DEV_AGGREGATOR_PREREGISTERED:
-        await precondition.register_aggregator(lfdi=aggregator_lfdi)
-    else:
-        logger.warning("Skipping aggregator registration ('DEV_AGGREGATOR_PREREGISTERED' environment variable is True)")
+    await precondition.register_aggregator(lfdi=aggregator_lfdi)
 
     # Save the aggregator details for later request validation
     request.app[APPKEY_AGGREGATOR].certificate = aggregator_certificate
@@ -145,17 +135,10 @@ async def init_handler(request: web.Request):
         client_sfdi=convert_lfdi_to_sfdi(aggregator_lfdi),
     )
 
-    # Apply preconditions (if present)
+    # Apply preconditions (if present) to get the database into the correct state for the test
     precond = active_test_procedure.definition.preconditions
-    if precond:
-        # Get the database into the correct state for the test procedure
-        if precond.db:
-            if DEV_SKIP_DB_PRECONDITIONS:
-                logger.warning(
-                    "Skipping database preconditions ('DEV_SKIP_DB_PRECONDITIONS' environment variable is True)"
-                )
-            else:
-                await precondition.apply_db_precondition(precondition=precond.db)
+    if precond and precond.db:
+        await precondition.apply_db_precondition(precondition=precond.db)
 
     logger.info(
         f"Test Procedure '{active_test_procedure.name}' started",

--- a/src/cactus_runner/app/handler.py
+++ b/src/cactus_runner/app/handler.py
@@ -92,6 +92,11 @@ async def init_handler(request: web.Request):
         interaction_type=ClientInteractionType.TEST_PROCEDURE_INIT, timestamp=datetime.now(timezone.utc)
     )
 
+    # Reset envoy database
+    # This must happen before the aggregator is registered or any test preconditions applied
+    logger.debug("Resetting envoy database")
+    await precondition.reset_db()
+
     # Get the name of the test procedure from the query parameter
     requested_test_procedure = request.query["test"]
     if requested_test_procedure is None:

--- a/src/cactus_runner/app/precondition.py
+++ b/src/cactus_runner/app/precondition.py
@@ -70,3 +70,24 @@ async def register_aggregator(lfdi: str) -> None:
 
         session.add(certificate_assignment)
         await session.commit()
+
+
+async def reset_db() -> None:
+    """Truncates all tables in the 'public' schema and resets sequences for id columns."""
+    # Adapted from https://stackoverflow.com/a/63227261
+    reset_sql = """
+SET row_security = off;
+SET timezone = 'UTC';
+
+DO $$ DECLARE
+    r RECORD;
+BEGIN
+    FOR r IN (SELECT tablename FROM pg_tables WHERE schemaname = 'public') LOOP
+        EXECUTE 'TRUNCATE TABLE ' || quote_ident(r.tablename) || ' RESTART IDENTITY CASCADE';
+    END LOOP;
+END $$;
+"""
+    async with open_connection() as connection:
+        async with connection.begin() as txn:
+            await connection.execute(text(reset_sql))
+            await txn.commit()

--- a/src/cactus_runner/app/precondition.py
+++ b/src/cactus_runner/app/precondition.py
@@ -76,9 +76,6 @@ async def reset_db() -> None:
     """Truncates all tables in the 'public' schema and resets sequences for id columns."""
     # Adapted from https://stackoverflow.com/a/63227261
     reset_sql = """
-SET row_security = off;
-SET timezone = 'UTC';
-
 DO $$ DECLARE
     r RECORD;
 BEGIN

--- a/tests/unit/app/test_precondition.py
+++ b/tests/unit/app/test_precondition.py
@@ -1,4 +1,10 @@
 import pytest
+from assertical.fake.generator import generate_class_instance
+from assertical.fixtures.postgres import generate_async_session
+from envoy.server.model.aggregator import Aggregator
+from envoy.server.model.doe import DynamicOperatingEnvelope, SiteControlGroup
+from envoy.server.model.site import Site
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncConnection
 
 from cactus_runner.app import precondition
@@ -13,3 +19,72 @@ async def test_apply_db_precondition_raises_exception_if_path_dne(mocker):
 
     with pytest.raises(precondition.UnableToApplyDatabasePrecondition):
         await precondition.apply_db_precondition(precondition="path-that-does-not-exist/file-that-does-not-exist.sql")
+
+
+@pytest.mark.anyio
+async def test_reset_db_on_content(pg_base_config):
+    """Tests that reset_db works if there is content to reset"""
+
+    # Insert some extra content
+    async with generate_async_session(pg_base_config) as session:
+        s1 = generate_class_instance(Site, seed=1, site_id=None, aggregator_id=0)
+        s2 = generate_class_instance(Site, seed=2, site_id=None, aggregator_id=1)
+
+        sc1 = generate_class_instance(SiteControlGroup, seed=3, site_control_group_id=None)
+
+        doe1 = generate_class_instance(
+            DynamicOperatingEnvelope,
+            seed=4,
+            dynamic_operating_envelope_id=None,
+            site_control_group_id=None,
+            site_id=None,
+            calculation_log_id=None,
+        )
+        doe2 = generate_class_instance(
+            DynamicOperatingEnvelope,
+            seed=5,
+            dynamic_operating_envelope_id=None,
+            site_control_group_id=None,
+            site_id=None,
+            calculation_log_id=None,
+        )
+
+        doe1.site = s1
+        doe1.site_control_group = sc1
+        doe2.site = s1
+        doe2.site_control_group = sc1
+
+        session.add(doe1)
+        session.add(doe2)
+        session.add(sc1)
+        session.add(s1)
+        session.add(s2)
+        await session.commit()
+
+    # Act
+    await precondition.reset_db()
+
+    # Assert that the DB is empty and that the sequences are reset to the beginning
+    async with generate_async_session(pg_base_config) as session:
+        # Counts should all be 0
+        assert (await session.execute(select(func.count()).select_from(Site))).scalar_one() == 0
+        assert (await session.execute(select(func.count()).select_from(Aggregator))).scalar_one() == 0
+        assert (await session.execute(select(func.count()).select_from(SiteControlGroup))).scalar_one() == 0
+        assert (await session.execute(select(func.count()).select_from(DynamicOperatingEnvelope))).scalar_one() == 0
+
+        # Inserts should also be inserting from 1
+        agg = generate_class_instance(Aggregator, seed=1, aggregator_id=None)
+        session.add(agg)
+        await session.flush()
+
+        assert agg.aggregator_id == 1, "Sequence should've been reset"
+
+        s1 = generate_class_instance(Site, seed=2, site_id=None, aggregator_id=1)
+        session.add(s1)
+        await session.flush()
+        assert s1.site_id == 1, "Sequence should've been reset"
+
+        sc1 = generate_class_instance(SiteControlGroup, seed=3, site_control_group_id=None)
+        session.add(sc1)
+        await session.flush()
+        assert sc1.site_control_group_id == 1, "Sequence should've been reset"


### PR DESCRIPTION
When a test procedure is initialised all tables in the public schema are truncated (and sequences for id's reset).

The environment variables DEV_AGGREGATOR_PREREGISTERED and DEV_SKIP_DB_PRECONDITIONS have been removed. These were a workaround for the fact the database might have entries from previous tests when performing local (dev) testing.