### PR TITLE
Serve request first

### DIFF
--- a/src/cactus_runner/app/event.py
+++ b/src/cactus_runner/app/event.py
@@ -1,12 +1,16 @@
 import logging
 from datetime import datetime, timedelta, timezone
 
+from aiohttp import web
 from cactus_test_definitions import Event
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from cactus_runner.app.action import apply_actions
 from cactus_runner.app.database import begin_session
 from cactus_runner.app.envoy_admin_client import EnvoyAdminClient
+from cactus_runner.app.shared import (
+    APPKEY_ENVOY_ADMIN_CLIENT,
+)
 from cactus_runner.app.variable_resolver import (
     resolve_variable_expressions_from_parameters,
 )
@@ -15,13 +19,20 @@ from cactus_runner.models import ActiveTestProcedure, Listener, StepStatus
 logger = logging.getLogger(__name__)
 
 
+UNRECOGNISED_STEP_NAME = "IGNORED"
+
+
 class WaitEventError(Exception):
     """Custom exception for wait event errors."""
 
 
 async def handle_event(
-    event: Event, active_test_procedure: ActiveTestProcedure, session: AsyncSession, envoy_client: EnvoyAdminClient
-) -> Listener | None:
+    event: Event,
+    active_test_procedure: ActiveTestProcedure,
+    session: AsyncSession,
+    envoy_client: EnvoyAdminClient,
+    request_served: bool = False,
+) -> tuple[Listener | None, bool]:
     """Triggers the action associated with any enabled listeners that match then event.
 
     Logs an error if the action was able to be executed.
@@ -33,12 +44,19 @@ async def handle_event(
     Returns:
         Listener: If successful return the listener that matched the event.
         None: If no listener matched.
+        bool: True if the handling of the event was deferred because the request should
+        be served beforehand.
     """
     # Check all listeners
     for listener in active_test_procedure.listeners:
         # Did any of the current listeners match?
         if listener.enabled and listener.event == event:
             logger.info(f"Event matched: {event=}")
+
+            # Some actions can only be applied after the request has been served by the envoy server
+            if "serve_request_first" in listener.event.parameters and listener.event.parameters["serve_request_first"]:
+                if not request_served:
+                    return listener, True
 
             # Perform actions associated with event
             await apply_actions(
@@ -48,9 +66,9 @@ async def handle_event(
                 envoy_client=envoy_client,
             )
 
-            return listener
+            return listener, False
 
-    return None
+    return None, False
 
 
 async def handle_wait_event(active_test_procedure: ActiveTestProcedure, envoy_client: EnvoyAdminClient):
@@ -93,3 +111,33 @@ async def handle_wait_event(active_test_procedure: ActiveTestProcedure, envoy_cl
 
                     # Update step status
                     active_test_procedure.step_status[listener.step] = StepStatus.RESOLVED
+
+
+async def update_test_procedure_progress(
+    request: web.Request, active_test_procedure: ActiveTestProcedure, request_served: bool = False
+) -> tuple[str, bool]:
+    """Calls handle_event and updates progress test procedure"""
+    # Update the progress of the test procedure
+    request_event = Event(type=f"{request.method}-request-received", parameters={"endpoint": request.path})
+    async with begin_session() as session:
+        envoy_client = request.app[APPKEY_ENVOY_ADMIN_CLIENT]
+        listener, serve_request_first = await handle_event(
+            event=request_event,
+            active_test_procedure=active_test_procedure,
+            session=session,
+            envoy_client=envoy_client,
+            request_served=request_served,
+        )
+
+    # Update step_status when action associated with event is handled.
+    # If we have a listener but serve_request_first is True, event handling has been
+    # deferred till after the request has been served.
+    if listener and not serve_request_first:
+        active_test_procedure.step_status[listener.step] = StepStatus.RESOLVED
+
+    # Determine which step of the test procedure was handled by this event.
+    # UNRECOGNISED_STEP_NAME indicates that no listener event was recognised by the
+    # test procedure and didn't progress it any further.
+    step_name = UNRECOGNISED_STEP_NAME if listener is None else listener.step
+
+    return step_name, serve_request_first

--- a/src/cactus_runner/app/event.py
+++ b/src/cactus_runner/app/event.py
@@ -42,8 +42,7 @@ async def handle_event(
         active_test_procedure (ActiveTestProcedure): The currently active test procedure.
 
     Returns:
-        Listener: If successful return the listener that matched the event.
-        None: If no listener matched.
+        Listener: If successful return the listener that matched the event, else None if no listener matched.
         bool: True if the handling of the event was deferred because the request should
         be served beforehand.
     """

--- a/src/cactus_runner/app/handler.py
+++ b/src/cactus_runner/app/handler.py
@@ -315,7 +315,7 @@ async def status_handler(request):
     return web.Response(status=http.HTTPStatus.OK, content_type="application/json", text=runner_status.to_json())
 
 
-async def forward_request(
+async def proxy_request(
     request: web.Request, remote_url: str, active_test_procedure: ActiveTestProcedure
 ) -> web.Response:
 
@@ -394,7 +394,7 @@ async def proxied_request_handler(request):
         request=request, active_test_procedure=active_test_procedure, request_served=False
     )
 
-    handler_response = await forward_request(
+    handler_response = await proxy_request(
         request=request, remote_url=remote_url, active_test_procedure=active_test_procedure
     )
 

--- a/src/cactus_runner/app/handler.py
+++ b/src/cactus_runner/app/handler.py
@@ -391,7 +391,7 @@ async def proxied_request_handler(request):
     logger.debug(f"{relative_url=} {remote_url=} {method=}")
 
     step_name, serve_request_first = await event.update_test_procedure_progress(
-        request=request, active_test_procedure=active_test_procedure
+        request=request, active_test_procedure=active_test_procedure, request_served=False
     )
 
     handler_response = await forward_request(

--- a/src/cactus_runner/app/proxy.py
+++ b/src/cactus_runner/app/proxy.py
@@ -12,15 +12,10 @@ async def proxy_request(
     # Forward the request to the reference server
     if active_test_procedure.communications_disabled:
         # We simulate communication loss as a series of HTTP 500 responses
-        headers = []
-        status = http.HTTPStatus.INTERNAL_SERVER_ERROR
-        body = "COMMS DISABLED"
+        return web.Response(status=http.HTTPStatus.INTERNAL_SERVER_ERROR, body="COMMS DISABLED")
     else:
         async with client.request(
             request.method, remote_url, headers=request.headers.copy(), allow_redirects=False, data=await request.read()
         ) as response:
             headers = response.headers.copy()
-            status = http.HTTPStatus(response.status)
-            body = await response.read()
-
-    return web.Response(headers=headers, status=status, body=body)
+            return web.Response(headers=headers, status=http.HTTPStatus(response.status), body=await response.read())

--- a/src/cactus_runner/app/proxy.py
+++ b/src/cactus_runner/app/proxy.py
@@ -1,0 +1,26 @@
+import http
+
+from aiohttp import client, web
+
+from cactus_runner.models import ActiveTestProcedure
+
+
+async def proxy_request(
+    request: web.Request, remote_url: str, active_test_procedure: ActiveTestProcedure
+) -> web.Response:
+
+    # Forward the request to the reference server
+    if active_test_procedure.communications_disabled:
+        # We simulate communication loss as a series of HTTP 500 responses
+        headers = []
+        status = http.HTTPStatus.INTERNAL_SERVER_ERROR
+        body = "COMMS DISABLED"
+    else:
+        async with client.request(
+            request.method, remote_url, headers=request.headers.copy(), allow_redirects=False, data=await request.read()
+        ) as response:
+            headers = response.headers.copy()
+            status = http.HTTPStatus(response.status)
+            body = await response.read()
+
+    return web.Response(headers=headers, status=status, body=body)

--- a/tests/unit/app/test_event.py
+++ b/tests/unit/app/test_event.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 from assertical.fake.sqlalchemy import assert_mock_session, create_mock_session

--- a/tests/unit/app/test_event.py
+++ b/tests/unit/app/test_event.py
@@ -210,7 +210,7 @@ async def test_handle_event_with_no_matches(test_event: Event, listeners: list[L
 
 
 @pytest.mark.asyncio
-async def test_update_test_procedure_progress(pg_empty_config):
+async def test_update_test_procedure_progress(pg_empty_config, mocker):
     # Arrange
     request_data = ""
     request_read = AsyncMock()
@@ -222,32 +222,23 @@ async def test_update_test_procedure_progress(pg_empty_config):
     request.read = request_read
 
     active_test_procedure = MagicMock()
-    #     request.app[APPKEY_RUNNER_STATE].request_history = []
-    #     request.app[APPKEY_RUNNER_STATE].active_test_procedure.step_status = {}
-    #
-    #     handler.SERVER_URL = ""  # Override the server url
-    #
-    #     handler.DEV_SKIP_AUTHORIZATION_CHECK = True
-    #
-    #     response_text = "RESPONSE-TEXT"
-    #     response_status = http.HTTPStatus.OK
-    #     response_headers = {"X-API-Key": "API-KEY"}
-    #     mock_client_request = mocker.patch("aiohttp.client.request")
-    #     mock_client_request.return_value.__aenter__.return_value.status = response_status
-    #     mock_client_request.return_value.__aenter__.return_value.read.return_value = response_text
-    #     mock_client_request.return_value.__aenter__.return_value.headers = response_headers
-    #
-    #     # spy_handle_event = mocker.spy(handler.event, "handle_event")
-    #     mock_handle_event = mocker.patch("cactus_runner.app.handler.update_test_procedure_progress")
-    #     mock_handle_event.return_value = (None, False)
-    #     matching_step_name = "STEP-NAME"
-    #     # mock_handle_event.return_value.step = matching_step_name
-    #
+    active_test_procedure.step_status = {}
+
+    request.app[APPKEY_RUNNER_STATE].active_test_procedure = active_test_procedure
+
+    listener = MagicMock()
+    step_name = "STEP-NAME"
+    listener.step = step_name
+    mock_handle_event = mocker.patch("cactus_runner.app.event.handle_event")
+    mock_handle_event.return_value = (listener, False)
+
     # Act
     matching_step_name, serve_request_first = await event.update_test_procedure_progress(
         request=request, active_test_procedure=active_test_procedure
     )
 
     # Assert
-
-    # assert request.app[APPKEY_RUNNER_STATE].active_test_procedure.step_status[matching_step_name] == StepStatus.RESOLVED
+    mock_handle_event.assert_called_once()
+    assert matching_step_name == step_name
+    assert serve_request_first == False
+    assert request.app[APPKEY_RUNNER_STATE].active_test_procedure.step_status[step_name] == StepStatus.RESOLVED

--- a/tests/unit/app/test_finalize.py
+++ b/tests/unit/app/test_finalize.py
@@ -8,7 +8,6 @@ import pytest
 from aiohttp.web import Response
 
 from cactus_runner.app import finalize
-from cactus_runner.app.database import DatabaseNotInitialisedError
 
 
 def test_get_zip_contents(mocker):

--- a/tests/unit/app/test_finalize.py
+++ b/tests/unit/app/test_finalize.py
@@ -8,6 +8,7 @@ import pytest
 from aiohttp.web import Response
 
 from cactus_runner.app import finalize
+from cactus_runner.app.database import DatabaseNotInitialisedError
 
 
 def test_get_zip_contents(mocker):
@@ -54,6 +55,11 @@ def test_get_zip_contents(mocker):
 def test_get_zip_contents_raises_databasedumperror(mocker):
 
     mocker.patch.object(finalize.shutil, "copyfile")  # prevent logfile copying
+    mock_get_postgres_dsn = mocker.patch(
+        "cactus_runner.app.finalize.get_postgres_dsn"
+    )  # Need to mock this out incase previous
+    mock_get_postgres_dsn.side_effect = DatabaseNotInitialisedError()
+    # test initialises DB.
 
     with pytest.raises(finalize.DatabaseDumpError):
         finalize.get_zip_contents(json_status_summary="", runner_logfile="", envoy_logfile="")

--- a/tests/unit/app/test_handler.py
+++ b/tests/unit/app/test_handler.py
@@ -14,6 +14,7 @@ from cactus_runner.models import (
     ClientInteractionType,
     RequestEntry,
     RunnerStatus,
+    StepStatus,
 )
 
 

--- a/tests/unit/app/test_handler.py
+++ b/tests/unit/app/test_handler.py
@@ -1,5 +1,5 @@
 import http
-from unittest.mock import ANY, AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 from aiohttp.web import Response

--- a/tests/unit/app/test_proxy.py
+++ b/tests/unit/app/test_proxy.py
@@ -1,0 +1,76 @@
+import http
+from unittest.mock import ANY, AsyncMock, MagicMock
+
+import pytest
+from aiohttp.web import Response
+
+from cactus_runner.app import proxy
+from cactus_runner.app.shared import APPKEY_RUNNER_STATE
+from cactus_runner.models import ActiveTestProcedure
+
+
+@pytest.mark.asyncio
+async def test_proxy_request(pg_empty_config, mocker):
+    # Arrange
+    request_data = ""
+    request_read = AsyncMock()
+    request_read.return_value = request_data
+    request = MagicMock()
+    request.path = "/dcap"
+    request.path_qs = "/dcap"
+    request.method = "GET"
+    request.read = request_read
+
+    response_text = "RESPONSE-TEXT"
+    response_status = http.HTTPStatus.OK
+    response_headers = {"X-API-Key": "API-KEY"}
+    mock_client_request = mocker.patch("aiohttp.client.request")
+    mock_client_request.return_value.__aenter__.return_value.status = response_status
+    mock_client_request.return_value.__aenter__.return_value.read.return_value = response_text
+    mock_client_request.return_value.__aenter__.return_value.headers = response_headers
+
+    active_test_procedure = MagicMock()
+    active_test_procedure.communications_disabled = False
+    remote_url = request.path
+
+    # Act
+    response = await proxy.proxy_request(
+        request=request, remote_url=remote_url, active_test_procedure=active_test_procedure
+    )
+
+    # Assert
+    mock_client_request.assert_called_once_with(
+        request.method, request.path_qs, headers=ANY, allow_redirects=False, data=request_data
+    )
+
+    #  ... verify we received the expected proxied response
+    #      i.e. the one supplied to 'mock_client_request'
+    assert isinstance(response, Response)
+    assert response.status == response_status
+    assert response.text == response_text
+    for key, value in response_headers.items():
+        assert key in response.headers
+        assert response.headers[key] == value
+
+
+@pytest.mark.asyncio
+async def test_proxy_request_disables_communications(pg_empty_config, mocker):
+    # Arrange
+    request = MagicMock()
+    mock_client_request = mocker.patch("aiohttp.client.request")
+    active_test_procedure = MagicMock()
+    active_test_procedure.communications_disabled = True
+    remote_url = ""
+
+    # Act
+    response = await proxy.proxy_request(
+        request=request, remote_url=remote_url, active_test_procedure=active_test_procedure
+    )
+
+    # Assert
+    assert mock_client_request.call_count == 0
+    assert response.status == http.HTTPStatus.INTERNAL_SERVER_ERROR
+
+
+def test_communications_disabled_defaults_false():
+    assert ActiveTestProcedure.communications_disabled is False

--- a/tests/unit/app/test_proxy.py
+++ b/tests/unit/app/test_proxy.py
@@ -5,7 +5,6 @@ import pytest
 from aiohttp.web import Response
 
 from cactus_runner.app import proxy
-from cactus_runner.app.shared import APPKEY_RUNNER_STATE
 from cactus_runner.models import ActiveTestProcedure
 
 


### PR DESCRIPTION
Implements serve_request_first functionality.

Listener events marked with serve_request_first parameter, proxy the request to the utility server first before applying the action (and updating the active test procedure state)