### PR TITLE
Initial support for the finish-test and edev registration actions

### DIFF
--- a/src/cactus_runner/app/action.py
+++ b/src/cactus_runner/app/action.py
@@ -265,7 +265,7 @@ async def apply_action(
 
     Args:
         action (Action): The Action to apply to the active test procedure.
-        active_test_procedure (ActiveTestProcedure): The currently active test procedure.
+        runner_state (RunnerState): The current state of the runner. If not active_test_procedure then this exits early.
 
     Raises:
         UnknownActionError: Raised if this function has no implementation for the provided `action.type`.

--- a/src/cactus_runner/app/action.py
+++ b/src/cactus_runner/app/action.py
@@ -19,12 +19,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from cactus_runner.app.envoy_admin_client import EnvoyAdminClient
 from cactus_runner.app.envoy_common import get_active_site
+from cactus_runner.app.finalize import finish_active_test
 from cactus_runner.app.variable_resolver import (
     resolve_variable_expressions_from_parameters,
 )
 from cactus_runner.models import (
     ActiveTestProcedure,
     Listener,
+    RunnerState,
 )
 
 logger = logging.getLogger(__name__)
@@ -96,6 +98,10 @@ async def action_remove_steps(
     for listener in listeners_to_remove:
         logger.info(f"ACTION remove-steps: Removing listener: {listener}")
         active_test_procedure.listeners.remove(listener)  # mutate the original listeners list
+
+
+async def action_finish_test(runner_state: RunnerState, session: AsyncSession):
+    await finish_active_test(runner_state, session)
 
 
 async def action_set_default_der_control(
@@ -238,16 +244,20 @@ async def action_register_end_device(
     await session.commit()
 
 
-def action_communications_loss(active_test_procedure: ActiveTestProcedure):
-    active_test_procedure.communications_disabled = False
+def action_communications_status(active_test_procedure: ActiveTestProcedure, resolved_parameters: dict[str, Any]):
+    comms_enabled: bool = resolved_parameters["enabled"]
+    active_test_procedure.communications_disabled = not comms_enabled
 
 
-def action_communications_restore(active_test_procedure: ActiveTestProcedure):
-    active_test_procedure.communications_disabled = True
+async def action_edev_registration_links(resolved_parameters: dict[str, Any], envoy_client: EnvoyAdminClient):
+    """Implements edev-registration-links action"""
+    links_enabled: bool = resolved_parameters["enabled"]
+
+    await envoy_client.update_runtime_config(RuntimeServerConfigRequest(disable_edev_registration=not links_enabled))
 
 
 async def apply_action(
-    action: Action, active_test_procedure: ActiveTestProcedure, session: AsyncSession, envoy_client: EnvoyAdminClient
+    action: Action, runner_state: RunnerState, session: AsyncSession, envoy_client: EnvoyAdminClient
 ):
     """Applies the action to the active test procedure.
 
@@ -260,18 +270,24 @@ async def apply_action(
     Raises:
         UnknownActionError: Raised if this function has no implementation for the provided `action.type`.
     """
+    active_test_procedure = runner_state.active_test_procedure
+    if not active_test_procedure:
+        return
+
     resolved_parameters = await resolve_variable_expressions_from_parameters(session, action.parameters)
 
+    logger.info(f"Executing action {action} with parameters {resolved_parameters}")
     try:
         match action.type:
             case "enable-steps":
                 await action_enable_steps(active_test_procedure, resolved_parameters)
                 return
-
             case "remove-steps":
                 await action_remove_steps(active_test_procedure, resolved_parameters)
                 return
-
+            case "finish-test":
+                await action_finish_test(runner_state, session)
+                return
             case "set-default-der-control":
                 await action_set_default_der_control(resolved_parameters, session, envoy_client)
                 return
@@ -290,13 +306,11 @@ async def apply_action(
             case "register-end-device":
                 await action_register_end_device(active_test_procedure, resolved_parameters, session)
                 return
-
-            case "communications-loss":
-                action_communications_loss(active_test_procedure)
+            case "communications-status":
+                action_communications_status(active_test_procedure, resolved_parameters)
                 return
-
-            case "communications-restore":
-                action_communications_restore(active_test_procedure)
+            case "edev-registration-links":
+                await action_edev_registration_links(resolved_parameters, envoy_client)
                 return
 
     except Exception as exc:
@@ -309,7 +323,7 @@ async def apply_action(
 async def apply_actions(
     session: AsyncSession,
     listener: Listener,
-    active_test_procedure: ActiveTestProcedure,
+    runner_state: RunnerState,
     envoy_client: EnvoyAdminClient,
 ):
     """Applies all actions for the given listener.
@@ -321,13 +335,7 @@ async def apply_actions(
         active_test_procedure (ActiveTestProcedure): The currently active test procedure.
     """
     for action in listener.actions:
-        logger.info(f"Executing action: {action=}")
         try:
-            await apply_action(
-                session=session,
-                action=action,
-                active_test_procedure=active_test_procedure,
-                envoy_client=envoy_client,
-            )
+            await apply_action(session=session, action=action, runner_state=runner_state, envoy_client=envoy_client)
         except (UnknownActionError, FailedActionError) as e:
             logger.error(f"Error. Unable to execute action for step={listener.step}: {repr(e)}")

--- a/src/cactus_runner/app/finalize.py
+++ b/src/cactus_runner/app/finalize.py
@@ -107,28 +107,30 @@ async def finish_active_test(runner_state: RunnerState, session: AsyncSession) -
 
     Populates and then returns the finished_zip_data for the active test procedure"""
 
-    atp = runner_state.active_test_procedure
-    if not atp:
+    active_test_procedure = runner_state.active_test_procedure
+    if not active_test_procedure:
         raise NoActiveTestProcedure()
 
-    if atp.is_finished():
-        logger.info(f"finish_active_test_procedure: active test procedure {atp.name} is already finished")
-        return cast(bytes, atp.finished_zip_data)  # The is_finished() check guarantees it's not None
+    if active_test_procedure.is_finished():
+        logger.info(
+            f"finish_active_test_procedure: active test procedure {active_test_procedure.name} is already finished"
+        )
+        return cast(bytes, active_test_procedure.finished_zip_data)  # The is_finished() check guarantees it's not None
 
-    logger.info(f"finish_active_test_procedure: '{atp.name}' will be finished")
+    logger.info(f"finish_active_test_procedure: '{active_test_procedure.name}' will be finished")
 
     json_status_summary = (
         await get_active_runner_status(
             session=session,
-            active_test_procedure=atp,
+            active_test_procedure=active_test_procedure,
             request_history=runner_state.request_history,
             last_client_interaction=runner_state.last_client_interaction,
         )
     ).to_json()
 
-    atp.finished_zip_data = get_zip_contents(
+    active_test_procedure.finished_zip_data = get_zip_contents(
         json_status_summary=json_status_summary,
         runner_logfile="logs/cactus_runner.jsonl",
         envoy_logfile="logs/envoy.jsonl",
     )
-    return atp.finished_zip_data
+    return active_test_procedure.finished_zip_data

--- a/src/cactus_runner/app/finalize.py
+++ b/src/cactus_runner/app/finalize.py
@@ -4,15 +4,23 @@ import shutil
 import subprocess  # nosec B404
 import tempfile
 from pathlib import Path
+from typing import cast
 
 from aiohttp import web
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from cactus_runner.app.database import DatabaseNotInitialisedError, get_postgres_dsn
+from cactus_runner.app.status import get_active_runner_status
+from cactus_runner.models import RunnerState
 
 logger = logging.getLogger(__name__)
 
 
 class DatabaseDumpError(Exception):
+    pass
+
+
+class NoActiveTestProcedure(Exception):
     pass
 
 
@@ -89,3 +97,38 @@ def create_response(json_status_summary: str, runner_logfile: str, envoy_logfile
             "Content-Disposition": f"attachment; filename={SUGGESTED_FILENAME}",
         },
     )
+
+
+async def finish_active_test(runner_state: RunnerState, session: AsyncSession) -> bytes:
+    """For the specified RunnerState - move the active test into a "Finished" state by calculating the final ZIP
+    contents. Raises NoActiveTestProcedure if there isn't an active test procedure for the specified RunnerState
+
+    If the active test is already finished - this will have no effect and will return the cached finished_zip_data
+
+    Populates and then returns the finished_zip_data for the active test procedure"""
+
+    atp = runner_state.active_test_procedure
+    if not atp:
+        raise NoActiveTestProcedure()
+
+    if atp.is_finished():
+        logger.info(f"finish_active_test_procedure: active test procedure {atp.name} is already finished")
+        return cast(bytes, atp.finished_zip_data)  # The is_finished() check guarantees it's not None
+
+    logger.info(f"finish_active_test_procedure: '{atp.name}' will be finished")
+
+    json_status_summary = (
+        await get_active_runner_status(
+            session=session,
+            active_test_procedure=atp,
+            request_history=runner_state.request_history,
+            last_client_interaction=runner_state.last_client_interaction,
+        )
+    ).to_json()
+
+    atp.finished_zip_data = get_zip_contents(
+        json_status_summary=json_status_summary,
+        runner_logfile="logs/cactus_runner.jsonl",
+        envoy_logfile="logs/envoy.jsonl",
+    )
+    return atp.finished_zip_data

--- a/src/cactus_runner/app/main.py
+++ b/src/cactus_runner/app/main.py
@@ -49,11 +49,10 @@ async def periodic_task(app: web.Application):
     """
     while True:
         try:
-            active_test_procedure = app[APPKEY_RUNNER_STATE].active_test_procedure
-            if active_test_procedure:
-                await event.handle_wait_event(
-                    active_test_procedure=active_test_procedure, envoy_client=app[APPKEY_ENVOY_ADMIN_CLIENT]
-                )
+            runner_state = app[APPKEY_RUNNER_STATE]
+            active_test_procedure = runner_state.active_test_procedure
+            if active_test_procedure and not active_test_procedure.is_finished():
+                await event.handle_wait_event(runner_state=runner_state, envoy_client=app[APPKEY_ENVOY_ADMIN_CLIENT])
         except Exception as e:
             # Catch and log uncaught exceptions to prevent periodic task from hanging
             logger.error(f"Uncaught exception in periodic task: {repr(e)}")

--- a/src/cactus_runner/models.py
+++ b/src/cactus_runner/models.py
@@ -33,6 +33,14 @@ class ActiveTestProcedure:
     client_lfdi: str  # The LFDI of the client certificate expected for the test
     client_sfdi: int  # The SFDI of the client certificate expected for the test
     communications_disabled: bool = False
+    finished_zip_data: bytes | None = (
+        None  # Finalised ZIP file. If not None - this test is "done" and shouldn't update any events/state
+    )
+
+    def is_finished(self) -> bool:
+        """True if the active test procedure has been marked as finished. That is, there is no more test data to
+        accumulate and any client events should be ignored"""
+        return self.finished_zip_data is not None
 
 
 @dataclass

--- a/tests/unit/app/test_action.py
+++ b/tests/unit/app/test_action.py
@@ -1,5 +1,6 @@
 import unittest.mock as mock
 from datetime import datetime, timezone
+from typing import Any
 
 import pytest
 from assertical.fake.generator import generate_class_instance
@@ -12,7 +13,9 @@ from envoy.server.model.site import Site
 from cactus_runner.app.action import (
     UnknownActionError,
     action_cancel_active_controls,
+    action_communications_status,
     action_create_der_control,
+    action_edev_registration_links,
     action_enable_steps,
     action_register_end_device,
     action_remove_steps,
@@ -22,21 +25,22 @@ from cactus_runner.app.action import (
     apply_action,
     apply_actions,
 )
-from cactus_runner.models import ActiveTestProcedure, Listener, StepStatus
+from cactus_runner.models import ActiveTestProcedure, Listener, RunnerState, StepStatus
 
 # This is a list of every action type paired with the handler function. This must be kept in sync with
 # the actions defined in cactus test definitions (via ACTION_PARAMETER_SCHEMA). This sync will be enforced
 ACTION_TYPE_TO_HANDLER: dict[str, str] = {
     "enable-steps": "action_enable_steps",
     "remove-steps": "action_remove_steps",
+    "finish-test": "action_finish_test",
     "set-default-der-control": "action_set_default_der_control",
     "create-der-control": "action_create_der_control",
     "cancel-active-der-controls": "action_cancel_active_controls",
     "set-poll-rate": "action_set_poll_rate",
     "set-post-rate": "action_set_post_rate",
     "register-end-device": "action_register_end_device",
-    "communications-loss": "action_communications_loss",
-    "communications-restore": "action_communications_restore",
+    "communications-status": "action_communications_status",
+    "edev-registration-links": "action_edev_registration_links",
 }
 
 
@@ -60,8 +64,9 @@ def test_ACTION_TYPE_TO_HANDLER_in_sync():
     ), "At least 1 action type have listed the same action handler. This is likely a bug"
 
 
-def create_testing_active_test_procedure(listeners: list[Listener]) -> ActiveTestProcedure:
-    return ActiveTestProcedure("test", None, listeners, {}, "", "")
+def create_testing_runner_state(listeners: list[Listener]) -> RunnerState:
+    atp = ActiveTestProcedure("test", None, listeners, {}, "", "")
+    return RunnerState(atp, [], None)
 
 
 @pytest.mark.anyio
@@ -73,11 +78,11 @@ async def test_action_enable_steps():
     listeners = [
         Listener(step=step_name, event=Event(type="", parameters={}), actions=[])
     ]  # listener defaults to disabled but should be enabled during this test
-    active_test_procedure = create_testing_active_test_procedure(listeners)
+    runner_state = create_testing_runner_state(listeners)
     resolved_parameters = {"steps": steps_to_enable}
 
     # Act
-    await action_enable_steps(active_test_procedure, resolved_parameters)
+    await action_enable_steps(runner_state.active_test_procedure, resolved_parameters)
 
     # Assert
     assert listeners[0].enabled
@@ -112,11 +117,11 @@ async def test_action_enable_steps():
 async def test_action_remove_steps(steps_to_disable: list[str], listeners: list[Listener]):
     # Arrange
     original_steps_to_disable = steps_to_disable.copy()
-    active_test_procedure = create_testing_active_test_procedure(listeners)
+    runner_state = create_testing_runner_state(listeners)
     resolved_parameters = {"steps": steps_to_disable}
 
     # Act
-    await action_remove_steps(active_test_procedure, resolved_parameters)
+    await action_remove_steps(runner_state.active_test_procedure, resolved_parameters)
 
     # Assert
     assert len(listeners) == 0  # all steps removed from list of listeners
@@ -141,7 +146,7 @@ async def test_apply_action(mocker, action: Action, apply_function_name: str):
     mock_envoy_client = mock.MagicMock()
 
     # Act
-    await apply_action(action, create_testing_active_test_procedure([]), mock_session, mock_envoy_client)
+    await apply_action(action, create_testing_runner_state([]), mock_session, mock_envoy_client)
 
     # Assert
     mock_apply_function.assert_called_once()
@@ -150,7 +155,7 @@ async def test_apply_action(mocker, action: Action, apply_function_name: str):
 
 @pytest.mark.anyio
 async def test__apply_action_raise_exception_for_unknown_action_type():
-    active_test_procedure = mock.MagicMock()
+    runner_state = mock.MagicMock()
     mock_session = create_mock_session()
     mock_envoy_client = mock.MagicMock()
 
@@ -159,7 +164,7 @@ async def test__apply_action_raise_exception_for_unknown_action_type():
             envoy_client=mock_envoy_client,
             session=mock_session,
             action=Action(type="NOT-A-VALID-ACTION-TYPE", parameters={}),
-            active_test_procedure=active_test_procedure,
+            runner_state=runner_state,
         )
     assert_mock_session(mock_session)
 
@@ -193,7 +198,7 @@ async def test__apply_action_raise_exception_for_unknown_action_type():
 @pytest.mark.anyio
 async def test_apply_actions(mocker, listener: Listener):
     # Arrange
-    active_test_procedure = mock.MagicMock()
+    runner_state = mock.MagicMock()
     mock_session = create_mock_session()
     mock_apply_action = mocker.patch("cactus_runner.app.action.apply_action")
     mock_envoy_client = mock.MagicMock()
@@ -202,7 +207,7 @@ async def test_apply_actions(mocker, listener: Listener):
     await apply_actions(
         session=mock_session,
         listener=listener,
-        active_test_procedure=active_test_procedure,
+        runner_state=runner_state,
         envoy_client=mock_envoy_client,
     )
 
@@ -350,7 +355,7 @@ async def test_action_set_post_rate(pg_base_config, envoy_admin_client):
 @pytest.mark.anyio
 async def test_action_register_end_device(pg_base_config):
     # Arrange
-    atp = generate_class_instance(ActiveTestProcedure, step_status={"1": StepStatus.PENDING})
+    atp = generate_class_instance(ActiveTestProcedure, step_status={"1": StepStatus.PENDING}, finished_zip_data=None)
     resolved_params = {
         "nmi": "abc",
         "registration_pin": 1234,
@@ -362,3 +367,53 @@ async def test_action_register_end_device(pg_base_config):
 
     # Assert
     assert pg_base_config.execute("select count(*) from site;").fetchone()[0] == 1
+
+
+@pytest.mark.parametrize(
+    "resolved_params, expected",
+    [
+        ({}, KeyError),
+        ({"blah": 123}, KeyError),
+        ({"enabled": True}, False),
+        ({"enabled": False}, True),
+        ({"other": False, "enabled": True}, False),
+    ],
+)
+def test_action_communications_status(resolved_params: dict[str, Any], expected: bool | type[Exception]):
+    """NOTE: The expected value is the expected value for comms DISABLED"""
+    for initial_comms_disabled_value in [True, False]:
+        atp = create_testing_runner_state([])
+        atp.communications_disabled = initial_comms_disabled_value
+
+        if isinstance(expected, type):
+            with pytest.raises(expected):
+                action_communications_status(atp, resolved_params)
+            assert atp.communications_disabled == initial_comms_disabled_value, "No change on error"
+        else:
+            action_communications_status(atp, resolved_params)
+            assert atp.communications_disabled == expected
+
+
+@pytest.mark.parametrize(
+    "resolved_params, expected_db_value",
+    [
+        ({}, KeyError),
+        ({"enabled": True}, False),
+        ({"enabled": False}, True),
+    ],
+)
+@pytest.mark.anyio
+async def test_action_edev_registration_links(
+    pg_base_config, envoy_admin_client, resolved_params: dict[str, Any], expected_db_value: bool | type[Exception]
+):
+    """NOTE: The expected value is the expected value for DISABLE edev registrations"""
+    if isinstance(expected_db_value, type):
+        with pytest.raises(expected_db_value):
+            await action_edev_registration_links(resolved_params, envoy_admin_client)
+        assert pg_base_config.execute("select count(*) from runtime_server_config;").fetchone()[0] == 0, "No DB update"
+    else:
+        await action_edev_registration_links(resolved_params, envoy_admin_client)
+        assert (
+            pg_base_config.execute("select disable_edev_registration from runtime_server_config;").fetchone()[0]
+            == expected_db_value
+        )

--- a/tests/unit/app/test_check.py
+++ b/tests/unit/app/test_check.py
@@ -79,7 +79,9 @@ def generate_active_test_procedure_steps(active_steps: list[str], all_steps: lis
     steps = dict([(s, Step(Event("wait", {}, None), [])) for s in all_steps])
     test_procedure = generate_class_instance(TestProcedure, steps=steps)
 
-    return generate_class_instance(ActiveTestProcedure, step_status={}, definition=test_procedure, listeners=listeners)
+    return generate_class_instance(
+        ActiveTestProcedure, step_status={}, definition=test_procedure, listeners=listeners, finished_zip_data=None
+    )
 
 
 def assert_check_result(cr: CheckResult, expected: bool):

--- a/tests/unit/app/test_event.py
+++ b/tests/unit/app/test_event.py
@@ -71,8 +71,8 @@ async def test_handle_event_with_matching_listener(
     # Arrange
     mock_all_checks_passing = mocker.patch("cactus_runner.app.event.all_checks_passing")
     mock_all_checks_passing.return_value = True
-    active_test_procedure = MagicMock()
-    active_test_procedure.listeners = listeners
+    runner_state = MagicMock()
+    runner_state.active_test_procedure.listeners = listeners
     mock_session = create_mock_session()
     mock_envoy_client = MagicMock()
 
@@ -80,7 +80,7 @@ async def test_handle_event_with_matching_listener(
     matched_listener, serve_request_first = await event.handle_event(
         session=mock_session,
         event=test_event,
-        active_test_procedure=active_test_procedure,
+        runner_state=runner_state,
         envoy_client=mock_envoy_client,
     )
 
@@ -106,8 +106,8 @@ async def test_handle_event_with_checks_failing(mocker):
     # Arrange
     mock_all_checks_passing = mocker.patch("cactus_runner.app.event.all_checks_passing")
     mock_all_checks_passing.return_value = False
-    active_test_procedure = MagicMock()
-    active_test_procedure.listeners = listeners
+    runner_state = MagicMock()
+    runner_state.active_test_procedure.listeners = listeners
     mock_session = create_mock_session()
     mock_envoy_client = MagicMock()
 
@@ -115,7 +115,7 @@ async def test_handle_event_with_checks_failing(mocker):
     matched_listener, serve_request_first = await event.handle_event(
         session=mock_session,
         event=test_event,
-        active_test_procedure=active_test_procedure,
+        runner_state=runner_state,
         envoy_client=mock_envoy_client,
     )
 
@@ -167,8 +167,8 @@ async def test_handle_event_with_checks_failing(mocker):
 @pytest.mark.asyncio
 async def test_handle_event_calls_apply_actions(mocker, test_event: Event, listeners: list[Listener]):
     # Arrange
-    active_test_procedure = MagicMock()
-    active_test_procedure.listeners = listeners
+    runner_state = MagicMock()
+    runner_state.active_test_procedure.listeners = listeners
     mock_session = create_mock_session()
     mock_envoy_client = MagicMock()
 
@@ -180,7 +180,7 @@ async def test_handle_event_calls_apply_actions(mocker, test_event: Event, liste
     await event.handle_event(
         session=mock_session,
         event=test_event,
-        active_test_procedure=active_test_procedure,
+        runner_state=runner_state,
         envoy_client=mock_envoy_client,
     )
 
@@ -233,8 +233,10 @@ async def test_handle_event_with_no_matches(mocker, test_event: Event, listeners
     # Arrange
     mock_all_checks_passing = mocker.patch("cactus_runner.app.event.all_checks_passing")
     mock_all_checks_passing.return_value = True
-    active_test_procedure = MagicMock()
-    active_test_procedure.listeners = listeners
+
+    runner_state = MagicMock()
+    runner_state.active_test_procedure.listeners = listeners
+
     mock_session = create_mock_session()
     mock_envoy_client = MagicMock()
 
@@ -242,7 +244,7 @@ async def test_handle_event_with_no_matches(mocker, test_event: Event, listeners
     listener, serve_request_first = await event.handle_event(
         session=mock_session,
         event=test_event,
-        active_test_procedure=active_test_procedure,
+        runner_state=runner_state,
         envoy_client=mock_envoy_client,
     )
 
@@ -273,15 +275,13 @@ async def test_update_test_procedure_progress(pg_empty_config, mocker):
     mock_handle_event.return_value = (listener, serve_request_first)
 
     # Act
-    matching_step_name, serve_request_first = await event.update_test_procedure_progress(
-        request=request, active_test_procedure=active_test_procedure
-    )
+    matching_step_name, serve_request_first = await event.update_test_procedure_progress(request=request)
 
     # Assert
     mock_handle_event.assert_called_once()
     assert matching_step_name == step_name
     assert serve_request_first == serve_request_first
-    assert request.app[APPKEY_RUNNER_STATE].active_test_procedure.step_status[step_name] == StepStatus.RESOLVED
+    assert active_test_procedure.step_status[step_name] == StepStatus.RESOLVED
 
 
 @pytest.mark.asyncio
@@ -306,9 +306,7 @@ async def test_update_test_procedure_progress_respects_serve_request_first(pg_em
     mock_handle_event.return_value = (listener, serve_request_first)
 
     # Act
-    matching_step_name, serve_request_first = await event.update_test_procedure_progress(
-        request=request, active_test_procedure=active_test_procedure
-    )
+    matching_step_name, serve_request_first = await event.update_test_procedure_progress(request=request)
 
     # Assert
     mock_handle_event.assert_called_once()

--- a/tests/unit/app/test_proxy.py
+++ b/tests/unit/app/test_proxy.py
@@ -59,6 +59,7 @@ async def test_proxy_request_disables_communications(pg_empty_config, mocker):
     mock_client_request = mocker.patch("aiohttp.client.request")
     active_test_procedure = MagicMock()
     active_test_procedure.communications_disabled = True
+    active_test_procedure.is_finished.return_value = False
     remote_url = ""
 
     # Act


### PR DESCRIPTION
* Support for finish-test action
* Support for enable-edev-registration action
* Tweaked communications-status action
* Introduced concept of a "finished" test (as part of finalization)