### PR TITLE
Had to change git dependencies to https for project to install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,8 @@ classifiers = [
 ]
 dependencies = [
   "aiohttp>=3.11.12,<4",
-  "cactus-test-definitions @ git+ssh://git@github.com/bsgip/cactus-test-definitions.git@main",
-  "envoy @ git+ssh://git@github.com/bsgip/envoy.git@main",
+  "cactus-test-definitions @ git+https://github.com/bsgip/cactus-test-definitions.git@main",
+  "envoy @ git+https://github.com/bsgip/envoy.git@main",
   "psycopg[binary]>=3.2.5,<4",
   "asyncpg",
 ]


### PR DESCRIPTION
when using ssh on my machine, running multiple keys means the typical "github.com" domain is aliased to its corresponding key, which doesn't work out of the box. Also probs need to have a github account when using ssh dependencies, which people may not have.