### PR TITLE
Reworked event handling

### DIFF
--- a/src/cactus_runner/app/action.py
+++ b/src/cactus_runner/app/action.py
@@ -64,11 +64,7 @@ async def action_enable_steps(
     for listener in active_test_procedure.listeners:
         if listener.step in steps_to_enable:
             logger.info(f"ACTION enable-steps: Enabling step {listener.step}")
-            listener.enabled = True
-
-            # Record the start time for steps with wait events
-            if listener.event.type == "wait":
-                listener.event.parameters["wait_start_timestamp"] = datetime.now(tz=timezone.utc)
+            listener.enabled_time = datetime.now(tz=timezone.utc)
 
 
 async def action_remove_steps(

--- a/src/cactus_runner/app/action.py
+++ b/src/cactus_runner/app/action.py
@@ -27,6 +27,7 @@ from cactus_runner.models import (
     ActiveTestProcedure,
     Listener,
     RunnerState,
+    StepStatus,
 )
 
 logger = logging.getLogger(__name__)
@@ -86,7 +87,7 @@ async def action_remove_steps(
     """
     steps_to_remove: list[str] = resolved_parameters["steps"]
 
-    listeners_to_remove = []
+    listeners_to_remove: list[Listener] = []
     for listener in active_test_procedure.listeners:
         if listener.step in steps_to_remove:
             listeners_to_remove.append(listener)
@@ -94,6 +95,7 @@ async def action_remove_steps(
     for listener in listeners_to_remove:
         logger.info(f"ACTION remove-steps: Removing listener: {listener}")
         active_test_procedure.listeners.remove(listener)  # mutate the original listeners list
+        active_test_procedure.step_status[listener.step] = StepStatus.RESOLVED
 
 
 async def action_finish_test(runner_state: RunnerState, session: AsyncSession):

--- a/src/cactus_runner/app/event.py
+++ b/src/cactus_runner/app/event.py
@@ -134,7 +134,8 @@ async def handle_event_trigger(
 
     # Check all listeners against this trigger
     triggered_listeners: list[Listener] = []
-    for listener in active_test_procedure.listeners:
+    listeners_to_eval = active_test_procedure.listeners.copy()  # We copy this as the underlying list might mutate
+    for listener in listeners_to_eval:
 
         if await is_listener_triggerable(listener, trigger, session):
             logger.info(f"handle_event_trigger: Matched Step {listener.step} for {trigger}")

--- a/src/cactus_runner/app/event.py
+++ b/src/cactus_runner/app/event.py
@@ -1,5 +1,8 @@
 import logging
-from datetime import datetime, timedelta, timezone
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import IntEnum, auto
+from http import HTTPMethod
 
 from aiohttp import web
 from cactus_test_definitions import Event
@@ -28,47 +31,125 @@ class WaitEventError(Exception):
     """Custom exception for wait event errors."""
 
 
-async def handle_event(
-    event: Event,
-    runner_state: RunnerState,
-    session: AsyncSession,
-    envoy_client: EnvoyAdminClient,
-    request_served: bool = False,
-) -> tuple[Listener | None, bool]:
-    """Triggers the action associated with any enabled listeners that match then event.
+class EventTriggerType(IntEnum):
+    """The different types of event triggers that can be generated (i.e things that can trigger an Event listener
+    to fire)"""
 
-    Logs an error if the action was able to be executed.
+    # HTTP GET/POST/PUT/DELETE (etc) request, initiated by the client to the CSIP-Aus endpoints, raised BEFORE
+    # the request is routed to the utility server.
+    CLIENT_REQUEST_BEFORE = auto()
+
+    # HTTP GET/POST/PUT/DELETE (etc) request, initiated by the client to the CSIP-Aus endpoints, raised AFTER
+    # the request has been routed to the utility server.
+    CLIENT_REQUEST_AFTER = auto()
+
+    # Raised on a regular interval in response to a period of time elapsing from the last TIME trigger
+    TIME = auto()
+
+
+@dataclass(frozen=True)
+class ClientRequestDetails:
+    """Basic details about a HTTP request initiated from a client"""
+
+    method: HTTPMethod  # The HTTP method being used in the request
+    path: str  # The requested path (no query params)
+
+
+@dataclass(frozen=True)
+class EventTrigger:
+    """Represents a *potential* trigger for an EventListener"""
+
+    type: EventTriggerType  # What is the underlying trigger of this request
+    time: datetime  # When was this event triggered (tz aware)
+    single_listener: bool  # If True - this can trigger a maximum of one Listener. False can trigger more than one.
+    client_request: ClientRequestDetails | None  # Only specified if type == CLIENT_REQUEST
+
+
+async def is_listener_triggerable(
+    listener: Listener,
+    trigger: EventTrigger,
+    session: AsyncSession,
+) -> bool:
+    """Returns True if the specified listener can be triggered by the specified trigger.
+
+    does NOT consider Event.checks - it's a pure comparison on whether the listener is active and whether the
+    underlying event matches the specified trigger"""
+
+    if not listener.enabled_time:
+        return False
+
+    # Is this listener for the variety of HTTP method "request-received" event types?
+    if (
+        listener.event.type.endswith("-request-received")
+        and trigger.type in {EventTriggerType.CLIENT_REQUEST_AFTER, EventTriggerType.CLIENT_REQUEST_BEFORE}
+        and trigger.client_request is not None
+    ):
+        expected_method_string = listener.event.type.split("-")[0]
+
+        # Make sure the method being listened for matches the method we received
+        if HTTPMethod(expected_method_string) != trigger.client_request.method:
+            return False
+
+        resolved_params = await resolve_variable_expressions_from_parameters(session, listener.event.parameters)
+        endpoint = resolved_params.get("endpoint", "")
+        serve_request_first = resolved_params.get("serve_request_first", False)
+
+        if endpoint != trigger.client_request.path:
+            return False
+
+        # Make sure that we are listening to the correct before/after serving event
+        if serve_request_first:
+            return trigger.type == EventTriggerType.CLIENT_REQUEST_AFTER
+        else:
+            return trigger.type == EventTriggerType.CLIENT_REQUEST_BEFORE
+
+    # If this listener is a wait event and the current trigger is time based
+    if listener.event.type == "wait" and trigger.type == EventTriggerType.TIME:
+
+        resolved_params = await resolve_variable_expressions_from_parameters(session, listener.event.parameters)
+        duration_seconds = resolved_params.get("duration_seconds", 0)
+
+        return (trigger.time - listener.enabled_time).seconds >= duration_seconds
+
+    # This event type / trigger doesn't match
+    return False
+
+
+async def handle_event_trigger(
+    trigger: EventTrigger, runner_state: RunnerState, session: AsyncSession, envoy_client: EnvoyAdminClient
+) -> list[Listener]:
+    """Runs through the currently active listeners for runner_state and potentially triggers their actions if trigger
+    can be matched to an Event. Time based triggers can potentially trigger multiple listeners, HTTP triggers will only
+    match at most a single trigger. Returns all triggered listeners (that had their actions run)
 
     Args:
-        event (Event): An Event to be matched against the test procedures enabled listeners.
-        runner_state (RunnerState): The current state of the runner (including an active test procedure).
+        trigger: The trigger being evaluated
+        runner_state: The current state of tests - requires an active_test_procedure to do anything
+        session: DB session for actions/parameter resolving
+        envoy_client: Client for interacting with admin server (for actions/checks that need it)
 
-    Returns:
-        Listener: If successful return the listener that matched the event, else None if no listener matched.
-        bool: True if the handling of the event was deferred because the request should
-        be served beforehand.
-    """
-
+    returns the list of all Listener's that were triggered by trigger."""
     active_test_procedure = runner_state.active_test_procedure
     if not active_test_procedure:
-        return None, False
+        logger.info(f"handle_event_trigger: no active test procedure for handling trigger {trigger}")
+        return []
 
-    # Check all listeners
+    if active_test_procedure.is_finished():
+        logger.info(f"handle_event_trigger: active test procedure is finished. Ignoring trigger {trigger}")
+        return []
+
+    # Check all listeners against this trigger
+    triggered_listeners: list[Listener] = []
     for listener in active_test_procedure.listeners:
-        # Did any of the current listeners match?
-        if listener.enabled and listener.event == event:
-            logger.info(f"Event matched: {event=}")
 
-            # Some actions can only be applied after the request has been served by the envoy server
-            if "serve_request_first" in listener.event.parameters and listener.event.parameters["serve_request_first"]:
-                if not request_served:
-                    return listener, True
+        if await is_listener_triggerable(listener, trigger, session):
+            logger.info(f"handle_event_trigger: Matched Step {listener.step} for {trigger}")
 
             if not await all_checks_passing(listener.event.checks, active_test_procedure, session):
-                logger.info(f"Event on Step {listener.step} is NOT being fired as one or more checks are failing.")
+                logger.info(f"handle_event_trigger: Step {listener.step} is NOT being triggered due to failing checks.")
                 continue
 
-            # Perform actions associated with event
+            logger.info(f"handle_event_trigger: Step {listener.step} is being triggered.")
             await apply_actions(
                 session=session,
                 listener=listener,
@@ -76,61 +157,34 @@ async def handle_event(
                 envoy_client=envoy_client,
             )
 
-            return listener, False
+            triggered_listeners.append(listener)
+            if trigger.single_listener:
+                break
 
-    return None, False
+    return triggered_listeners
 
 
-async def handle_wait_event(runner_state: RunnerState, envoy_client: EnvoyAdminClient):
-    """Checks for any expired wait events on enabled listeners and triggers their actions.
+def generate_time_trigger() -> EventTrigger:
+    """Generates an EventTrigger representing a poll of the TIME event"""
+    return EventTrigger(
+        type=EventTriggerType.TIME, time=datetime.now(timezone.utc), single_listener=False, client_request=None
+    )
+
+
+def generate_client_request_trigger(request: web.Request, before_serving: bool) -> EventTrigger:
+    """Generates an EventTrigger representing the specified web.Request
 
     Args:
-        runner_state (RunnerState): The current state of the runner (including an active test procedure).
-        envoy_client (EnvoyAdminClient): An instance of an envoy admin client.
+        request: The request to interrogate (body will NOT be read)
+        before_serving: Is this an event trigger for BEFORE the request is served to envoy (True) or after (False)"""
 
-    Raises:
-        WaitEventError: If the wait event is missing a start timestamp or duration.
-    """
-    active_test_procedure = runner_state.active_test_procedure
-    if not active_test_procedure:
-        return
-
-    now = datetime.now(timezone.utc)
-
-    # Loop over enabled listeners with (active) wait events
-    for listener in active_test_procedure.listeners:
-        if listener.enabled and listener.event.type == "wait":
-            async with begin_session() as session:
-                resolved_parameters = await resolve_variable_expressions_from_parameters(
-                    session, listener.event.parameters
-                )
-                try:
-                    wait_start = resolved_parameters["wait_start_timestamp"]
-                except KeyError:
-                    raise WaitEventError("Wait event missing start timestamp ('wait_start_timestamp')")
-                try:
-                    wait_duration_sec = resolved_parameters["duration_seconds"]
-                except KeyError:
-                    raise WaitEventError("Wait event missing duration ('duration_seconds')")
-
-                # Determine if wait period has expired
-                if now - wait_start >= timedelta(seconds=wait_duration_sec):
-                    if not await all_checks_passing(listener.event.checks, active_test_procedure, session):
-                        logger.info(f"Step {listener.step} is NOT being fired as one or more checks are failing.")
-                        continue
-
-                    # Apply actions
-                    await apply_actions(
-                        session=session,
-                        listener=listener,
-                        runner_state=runner_state,
-                        envoy_client=envoy_client,
-                    )
-
-                    # Update step status
-                    active_test_procedure.step_status[listener.step] = StepStatus.RESOLVED
-
-                await session.commit()
+    trigger_type = EventTriggerType.CLIENT_REQUEST_BEFORE if before_serving else EventTriggerType.CLIENT_REQUEST_AFTER
+    return EventTrigger(
+        type=trigger_type,
+        time=datetime.now(timezone.utc),
+        single_listener=True,
+        client_request=ClientRequestDetails(HTTPMethod(request.method), request.path),
+    )
 
 
 async def update_test_procedure_progress(request: web.Request, request_served: bool = False) -> tuple[str, bool]:

--- a/src/cactus_runner/app/handler.py
+++ b/src/cactus_runner/app/handler.py
@@ -395,7 +395,7 @@ async def proxied_request_handler(request: web.Request):
     # Fire "after request" event trigger (only if an event didn't handle the before event)
     if not handling_listeners:
         async with begin_session() as session:
-            await event.handle_event_trigger(
+            handling_listeners = await event.handle_event_trigger(
                 trigger=event.generate_client_request_trigger(request, before_serving=False),
                 runner_state=runner_state,
                 session=session,

--- a/src/cactus_runner/app/handler.py
+++ b/src/cactus_runner/app/handler.py
@@ -311,7 +311,7 @@ async def status_handler(request):
     return web.Response(status=http.HTTPStatus.OK, content_type="application/json", text=runner_status.to_json())
 
 
-async def proxied_request_handler(request):
+async def proxied_request_handler(request: web.Request):
     """Handler for requests that should be forwarded to the utility server.
 
     The handler also logs all requests to `request.app[APPKEY_RUNNER_STATE].request_history`, tagging

--- a/src/cactus_runner/app/handler.py
+++ b/src/cactus_runner/app/handler.py
@@ -13,6 +13,7 @@ from cactus_runner.app.env import (
     DEV_SKIP_AUTHORIZATION_CHECK,
     SERVER_URL,
 )
+from cactus_runner.app.envoy_admin_client import EnvoyAdminClient
 from cactus_runner.app.shared import (
     APPKEY_AGGREGATOR,
     APPKEY_ENVOY_ADMIN_CLIENT,
@@ -184,7 +185,7 @@ async def start_handler(request: web.Request):
 
     # We cannot start another test procedure if one is already running.
     # If there are active listeners then the test procedure must have already been started.
-    listener_state = [listener.enabled for listener in active_test_procedure.listeners]
+    listener_state = [listener.enabled_time for listener in active_test_procedure.listeners]
     if any(listener_state):
         return web.Response(
             status=http.HTTPStatus.CONFLICT,
@@ -206,9 +207,9 @@ async def start_handler(request: web.Request):
 
             await session.commit()  # Actions can write updates to the DB directly
 
-    # Active the first listener
+    # Activate the first listener
     if active_test_procedure.listeners:
-        active_test_procedure.listeners[0].enabled = True
+        active_test_procedure.listeners[0].enabled_time = datetime.now(tz=timezone.utc)
 
     logger.info(
         f"Test Procedure '{active_test_procedure.name}' started.",
@@ -365,7 +366,7 @@ async def proxied_request_handler(request: web.Request):
         )
 
     # Update last client interaction
-    request.app[APPKEY_RUNNER_STATE].last_client_interaction = ClientInteraction(
+    runner_state.last_client_interaction = ClientInteraction(
         interaction_type=ClientInteractionType.PROXIED_REQUEST, timestamp=request_timestamp
     )
 
@@ -375,14 +376,38 @@ async def proxied_request_handler(request: web.Request):
     method = request.method
     logger.debug(f"{relative_url=} {remote_url=} {method=}")
 
-    step_name, serve_request_first = await event.update_test_procedure_progress(request=request, request_served=False)
+    # Fire "before request" event trigger
+    envoy_client: EnvoyAdminClient = request.app[APPKEY_ENVOY_ADMIN_CLIENT]
+    async with begin_session() as session:
+        handling_listeners = await event.handle_event_trigger(
+            trigger=event.generate_client_request_trigger(request, before_serving=True),
+            runner_state=runner_state,
+            session=session,
+            envoy_client=envoy_client,
+        )
+        await session.commit()
 
+    # Proxy the request to the utility server
     handler_response = await proxy.proxy_request(
         request=request, remote_url=remote_url, active_test_procedure=active_test_procedure
     )
 
-    if serve_request_first:
-        step_name, _ = await event.update_test_procedure_progress(request=request, request_served=True)
+    # Fire "after request" event trigger (only if an event didn't handle the before event)
+    if not handling_listeners:
+        async with begin_session() as session:
+            await event.handle_event_trigger(
+                trigger=event.generate_client_request_trigger(request, before_serving=False),
+                runner_state=runner_state,
+                session=session,
+                envoy_client=envoy_client,
+            )
+            await session.commit()
+
+    # There will only ever be a maximum of 1 entry in this list
+    # The request events will only trigger a max of one listener
+    step_name: str = event.UNRECOGNISED_STEP_NAME
+    if handling_listeners:
+        step_name = handling_listeners[0].step
 
     # Record in request history
     request_entry = RequestEntry(

--- a/src/cactus_runner/app/main.py
+++ b/src/cactus_runner/app/main.py
@@ -13,7 +13,7 @@ from cactus_test_definitions import TestProcedureConfig
 
 from cactus_runner import __version__
 from cactus_runner.app import event, handler
-from cactus_runner.app.database import initialise_database_connection
+from cactus_runner.app.database import begin_session, initialise_database_connection
 from cactus_runner.app.env import (
     APP_HOST,
     APP_PORT,
@@ -49,10 +49,14 @@ async def periodic_task(app: web.Application):
     """
     while True:
         try:
-            runner_state = app[APPKEY_RUNNER_STATE]
-            active_test_procedure = runner_state.active_test_procedure
-            if active_test_procedure and not active_test_procedure.is_finished():
-                await event.handle_wait_event(runner_state=runner_state, envoy_client=app[APPKEY_ENVOY_ADMIN_CLIENT])
+            async with begin_session() as session:
+                await event.handle_event_trigger(
+                    trigger=event.generate_time_trigger(),
+                    runner_state=app[APPKEY_RUNNER_STATE],
+                    session=session,
+                    envoy_client=app[APPKEY_ENVOY_ADMIN_CLIENT],
+                )
+
         except Exception as e:
             # Catch and log uncaught exceptions to prevent periodic task from hanging
             logger.error(f"Uncaught exception in periodic task: {repr(e)}")

--- a/src/cactus_runner/app/main.py
+++ b/src/cactus_runner/app/main.py
@@ -56,6 +56,7 @@ async def periodic_task(app: web.Application):
                     session=session,
                     envoy_client=app[APPKEY_ENVOY_ADMIN_CLIENT],
                 )
+                await session.commit()
 
         except Exception as e:
             # Catch and log uncaught exceptions to prevent periodic task from hanging

--- a/src/cactus_runner/models.py
+++ b/src/cactus_runner/models.py
@@ -16,7 +16,7 @@ class Listener:
     step: str
     event: Event
     actions: list[Any]
-    enabled: bool = False
+    enabled_time: datetime | None = None  # Set to the TZ aware datetime when this Listener was enabled. None = disabled
 
 
 class StepStatus(Enum):

--- a/tests/unit/app/test_action.py
+++ b/tests/unit/app/test_action.py
@@ -96,20 +96,35 @@ async def test_action_enable_steps():
         (
             ["step1"],
             [
-                Listener(step="step1", event=Event(type="", parameters={}), actions=[], enabled=True),
+                Listener(
+                    step="step1",
+                    event=Event(type="", parameters={}),
+                    actions=[],
+                    enabled_time=datetime(2000, 1, 1, tzinfo=timezone.utc),
+                ),
             ],
         ),
         (
             ["step1"],
             [
-                Listener(step="step1", event=Event(type="", parameters={}), actions=[], enabled=False),
+                Listener(step="step1", event=Event(type="", parameters={}), actions=[], enabled_time=None),
             ],
         ),
         (
             ["step1", "step2"],
             [
-                Listener(step="step1", event=Event(type="", parameters={}), actions=[], enabled=True),
-                Listener(step="step2", event=Event(type="", parameters={}), actions=[], enabled=True),
+                Listener(
+                    step="step1",
+                    event=Event(type="", parameters={}),
+                    actions=[],
+                    enabled_time=datetime(2000, 1, 1, tzinfo=timezone.utc),
+                ),
+                Listener(
+                    step="step2",
+                    event=Event(type="", parameters={}),
+                    actions=[],
+                    enabled_time=datetime(2000, 1, 1, tzinfo=timezone.utc),
+                ),
             ],
         ),
     ],
@@ -127,6 +142,10 @@ async def test_action_remove_steps(steps_to_disable: list[str], listeners: list[
     # Assert
     assert len(listeners) == 0  # all steps removed from list of listeners
     assert steps_to_disable == original_steps_to_disable  # check we are mutating 'steps_to_diable'
+    for step in steps_to_disable:
+        assert (
+            runner_state.active_test_procedure.step_status[step] == StepStatus.RESOLVED
+        ), "Check we update step_status"
 
 
 @pytest.mark.parametrize(
@@ -177,13 +196,13 @@ async def test__apply_action_raise_exception_for_unknown_action_type():
             step="step",
             event=Event(type="GET-request-received", parameters={"endpoint": "/dcap"}),
             actions=[],
-            enabled=True,
+            enabled_time=datetime(2000, 1, 1, tzinfo=timezone.utc),
         ),  # no actions for listener
         Listener(
             step="step",
             event=Event(type="GET-request-received", parameters={"endpoint": "/dcap"}),
             actions=[Action(type="enable-steps", parameters={})],
-            enabled=True,
+            enabled_time=datetime(2000, 1, 1, tzinfo=timezone.utc),
         ),  # 1 action for listener
         Listener(
             step="step",
@@ -192,7 +211,7 @@ async def test__apply_action_raise_exception_for_unknown_action_type():
                 Action(type="enable-steps", parameters={}),
                 Action(type="remove-steps", parameters={}),
             ],
-            enabled=True,
+            enabled_time=datetime(2000, 1, 1, tzinfo=timezone.utc),
         ),  # 2 actions for listener
     ],
 )

--- a/tests/unit/app/test_action.py
+++ b/tests/unit/app/test_action.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 import pytest
+from assertical.asserts.time import assert_nowish
 from assertical.fake.generator import generate_class_instance
 from assertical.fake.sqlalchemy import assert_mock_session, create_mock_session
 from assertical.fixtures.postgres import generate_async_session
@@ -84,7 +85,8 @@ async def test_action_enable_steps():
     await action_enable_steps(runner_state.active_test_procedure, resolved_parameters)
 
     # Assert
-    assert listeners[0].enabled
+    assert_nowish(listeners[0].enabled_time)
+    assert listeners[0].enabled_time.tzinfo, "Need timezone aware datetime"
     assert steps_to_enable == original_steps_to_enable  # Ensure we are not mutating step_to_enable
 
 

--- a/tests/unit/app/test_event.py
+++ b/tests/unit/app/test_event.py
@@ -1,6 +1,10 @@
-from unittest.mock import MagicMock
+from datetime import datetime, timezone
+from http import HTTPMethod
+from unittest.mock import MagicMock, patch
 
 import pytest
+from aiohttp import web
+from assertical.asserts.time import assert_nowish
 from assertical.fake.sqlalchemy import assert_mock_session, create_mock_session
 from cactus_test_definitions import Event
 
@@ -9,6 +13,301 @@ from cactus_runner.app.shared import (
     APPKEY_RUNNER_STATE,
 )
 from cactus_runner.models import Listener, StepStatus
+
+
+def test_generate_time_trigger():
+    """Simple sanity check"""
+    trigger = event.generate_time_trigger()
+    assert isinstance(trigger, event.EventTrigger)
+    assert_nowish(trigger.time)
+    assert trigger.time.tzinfo
+    assert trigger.type == event.EventTriggerType.TIME
+    assert trigger.client_request is None
+
+
+@pytest.mark.parametrize(
+    "request_method, request_path, before_serving",
+    [
+        ("GET", "/", True),
+        ("GET", "/", False),
+        ("POST", "/foo/bar", True),
+        ("POST", "/foo/bar", False),
+        ("DELETE", "/foo/bar/baz", True),
+        ("DELETE", "/foo/bar/baz", False),
+        ("PUT", "/foo/bar", True),
+        ("PUT", "/foo/bar/baz", False),
+    ],
+)
+def test_generate_client_request_trigger(request_method: str, request_path: str, before_serving: bool):
+    """Checks basic parsing of AIOHttp requests"""
+
+    mock_request = MagicMock()
+    mock_request.method = request_method
+    mock_request.path = request_path
+
+    trigger = event.generate_client_request_trigger(mock_request, before_serving)
+    assert isinstance(trigger, event.EventTrigger)
+    assert_nowish(trigger.time)
+    assert trigger.time.tzinfo
+
+    if before_serving:
+        assert trigger.type == event.EventTriggerType.CLIENT_REQUEST_BEFORE
+    else:
+        assert trigger.type == event.EventTriggerType.CLIENT_REQUEST_AFTER
+
+    assert isinstance(trigger.client_request, event.ClientRequestDetails)
+    assert isinstance(trigger.client_request.method, HTTPMethod)
+    assert trigger.client_request.method == request_method
+    assert isinstance(trigger.client_request.path, str)
+    assert trigger.client_request.path == request_path
+
+
+@pytest.mark.parametrize(
+    "trigger, listener, expected",
+    [
+        (
+            event.EventTrigger(event.EventTriggerType.TIME, datetime(2022, 11, 10, tzinfo=timezone.utc), False, None),
+            Listener(
+                step="step",
+                event=Event(type="GET-request-received", parameters={"endpoint": "/dcap"}),
+                actions=[],
+                enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
+            ),
+            False,  # Wrong type of event
+        ),
+        (
+            event.EventTrigger(event.EventTriggerType.TIME, datetime(2022, 11, 10, tzinfo=timezone.utc), False, None),
+            Listener(
+                step="step",
+                event=Event(type="unsupported-event-type", parameters={}),
+                actions=[],
+                enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
+            ),
+            False,  # Unrecognized event type
+        ),
+        (
+            event.EventTrigger(event.EventTriggerType.TIME, datetime(2022, 11, 10, tzinfo=timezone.utc), False, None),
+            Listener(
+                step="step",
+                event=Event(type="wait", parameters={"duration_seconds": 300}),
+                actions=[],
+                enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
+            ),
+            False,  # This was enabled after the event trigger (negative time)
+        ),
+        (
+            event.EventTrigger(
+                event.EventTriggerType.TIME, datetime(2024, 11, 10, 5, 30, 0, tzinfo=timezone.utc), False, None
+            ),
+            Listener(
+                step="step",
+                event=Event(type="wait", parameters={"duration_seconds": 300}),
+                actions=[],
+                enabled_time=datetime(2024, 11, 10, 5, 24, 0, tzinfo=timezone.utc),
+            ),
+            True,
+        ),
+        (
+            event.EventTrigger(
+                event.EventTriggerType.TIME, datetime(2024, 11, 10, 5, 30, 0, tzinfo=timezone.utc), False, None
+            ),
+            Listener(
+                step="step",
+                event=Event(type="wait", parameters={"duration_seconds": 300}),
+                actions=[],
+                enabled_time=None,
+            ),
+            False,  # This listener is NOT enabled
+        ),
+        (
+            event.EventTrigger(
+                event.EventTriggerType.TIME, datetime(2024, 11, 10, 5, 30, 0, tzinfo=timezone.utc), False, None
+            ),
+            Listener(
+                step="step",
+                event=Event(type="wait", parameters={"duration_seconds": 300}),
+                actions=[],
+                enabled_time=datetime(2024, 11, 10, 5, 26, 0, tzinfo=timezone.utc),
+            ),
+            False,  # Not enough time elapsed
+        ),
+        (
+            event.EventTrigger(
+                event.EventTriggerType.CLIENT_REQUEST_BEFORE,
+                datetime(2022, 11, 10, tzinfo=timezone.utc),
+                False,
+                event.ClientRequestDetails(HTTPMethod.GET, "/foo/bar"),
+            ),
+            Listener(
+                step="step",
+                event=Event(type="GET-request-received", parameters={"endpoint": "/foo/bar"}),
+                actions=[],
+                enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
+            ),
+            True,
+        ),
+        (
+            event.EventTrigger(
+                event.EventTriggerType.CLIENT_REQUEST_BEFORE,
+                datetime(2022, 11, 10, tzinfo=timezone.utc),
+                False,
+                event.ClientRequestDetails(HTTPMethod.POST, "/foo/bar"),
+            ),
+            Listener(
+                step="step",
+                event=Event(type="POST-request-received", parameters={"endpoint": "/foo/bar"}),
+                actions=[],
+                enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
+            ),
+            True,
+        ),
+        (
+            event.EventTrigger(
+                event.EventTriggerType.CLIENT_REQUEST_BEFORE,
+                datetime(2022, 11, 10, tzinfo=timezone.utc),
+                False,
+                event.ClientRequestDetails(HTTPMethod.PUT, "/foo/bar"),
+            ),
+            Listener(
+                step="step",
+                event=Event(type="PUT-request-received", parameters={"endpoint": "/foo/bar"}),
+                actions=[],
+                enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
+            ),
+            True,
+        ),
+        (
+            event.EventTrigger(
+                event.EventTriggerType.CLIENT_REQUEST_BEFORE,
+                datetime(2022, 11, 10, tzinfo=timezone.utc),
+                False,
+                event.ClientRequestDetails(HTTPMethod.GET, "/foo/bar"),
+            ),
+            Listener(
+                step="step",
+                event=Event(
+                    type="GET-request-received", parameters={"endpoint": "/foo/bar", "serve_request_first": False}
+                ),
+                actions=[],
+                enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
+            ),
+            True,
+        ),
+        (
+            event.EventTrigger(
+                event.EventTriggerType.CLIENT_REQUEST_AFTER,
+                datetime(2022, 11, 10, tzinfo=timezone.utc),
+                False,
+                event.ClientRequestDetails(HTTPMethod.GET, "/foo/bar"),
+            ),
+            Listener(
+                step="step",
+                event=Event(
+                    type="GET-request-received", parameters={"endpoint": "/foo/bar", "serve_request_first": True}
+                ),
+                actions=[],
+                enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
+            ),
+            True,
+        ),
+        (
+            event.EventTrigger(
+                event.EventTriggerType.CLIENT_REQUEST_AFTER,
+                datetime(2022, 11, 10, tzinfo=timezone.utc),
+                False,
+                event.ClientRequestDetails(HTTPMethod.GET, "/foo/bar"),
+            ),
+            Listener(
+                step="step",
+                event=Event(type="GET-request-received", parameters={"endpoint": "/foo/bar"}),
+                actions=[],
+                enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
+            ),
+            False,  # Without serve_request_first: True - Only BEFORE events will fire
+        ),
+        (
+            event.EventTrigger(
+                event.EventTriggerType.CLIENT_REQUEST_BEFORE,
+                datetime(2022, 11, 10, tzinfo=timezone.utc),
+                False,
+                event.ClientRequestDetails(HTTPMethod.GET, "/foo"),
+            ),
+            Listener(
+                step="step",
+                event=Event(type="GET-request-received", parameters={"endpoint": "/foo/bar"}),
+                actions=[],
+                enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
+            ),
+            False,  # Wrong endpoint
+        ),
+        (
+            event.EventTrigger(
+                event.EventTriggerType.CLIENT_REQUEST_BEFORE,
+                datetime(2022, 11, 10, tzinfo=timezone.utc),
+                False,
+                event.ClientRequestDetails(HTTPMethod.GET, "/foo/bar"),
+            ),
+            Listener(
+                step="step",
+                event=Event(type="GET-request-received", parameters={"endpoint": "/foo"}),
+                actions=[],
+                enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
+            ),
+            False,  # Wrong endpoint
+        ),
+        (
+            event.EventTrigger(
+                event.EventTriggerType.CLIENT_REQUEST_BEFORE,
+                datetime(2022, 11, 10, tzinfo=timezone.utc),
+                False,
+                event.ClientRequestDetails(HTTPMethod.POST, "/foo/bar"),
+            ),
+            Listener(
+                step="step",
+                event=Event(type="GET-request-received", parameters={"endpoint": "/foo/bar"}),
+                actions=[],
+                enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
+            ),
+            False,  # Wrong method
+        ),
+        (
+            event.EventTrigger(
+                event.EventTriggerType.CLIENT_REQUEST_BEFORE,
+                datetime(2022, 11, 10, tzinfo=timezone.utc),
+                False,
+                event.ClientRequestDetails(HTTPMethod.GET, "/foo/bar"),
+            ),
+            Listener(
+                step="step",
+                event=Event(type="GET-request-received", parameters={"endpoint": "/foo/bar"}),
+                actions=[],
+                enabled_time=None,
+            ),
+            False,  # Not enabled
+        ),
+    ],
+)
+@patch("cactus_runner.app.event.resolve_variable_expressions_from_parameters")
+@pytest.mark.anyio
+async def test_is_listener_triggerable(
+    mock_resolve_variable_expressions_from_parameters: MagicMock,
+    trigger: event.EventTrigger,
+    listener: Listener,
+    expected: bool,
+):
+    """Tests various combinations of listeners and events to see if they could potentially trigger"""
+
+    # Arrange
+    mock_session = create_mock_session()
+    mock_resolve_variable_expressions_from_parameters.side_effect = lambda session, parameters: parameters
+
+    result = await event.is_listener_triggerable(listener, trigger, mock_session)
+
+    # Assert
+    assert isinstance(result, bool)
+    assert result == expected
+    assert_mock_session(mock_session)
+    assert all([ca[0] is mock_session for ca in mock_resolve_variable_expressions_from_parameters.call_args_list])
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/app/test_event.py
+++ b/tests/unit/app/test_event.py
@@ -3,7 +3,6 @@ from http import HTTPMethod
 from unittest.mock import MagicMock, patch
 
 import pytest
-from aiohttp import web
 from assertical.asserts.time import assert_nowish
 from assertical.asserts.type import assert_list_type
 from assertical.fake.generator import generate_class_instance
@@ -11,10 +10,7 @@ from assertical.fake.sqlalchemy import assert_mock_session, create_mock_session
 from cactus_test_definitions import Event
 
 from cactus_runner.app import event
-from cactus_runner.app.shared import (
-    APPKEY_RUNNER_STATE,
-)
-from cactus_runner.models import ActiveTestProcedure, Listener, RunnerState, StepStatus
+from cactus_runner.models import ActiveTestProcedure, Listener, RunnerState
 
 
 def test_generate_time_trigger():
@@ -413,7 +409,7 @@ async def test_handle_event_trigger_normal_operation(
         assert session is mock_session
         assert active_test_procedure is input_runner_state.active_test_procedure
 
-        idx = find_index(checks, [l.event.checks for l in listeners])
+        idx = find_index(checks, [listener.event.checks for listener in listeners])
         assert idx is not None, "Couldn't find checks. This is a test setup issue."
 
         return idx in check_indexes

--- a/tests/unit/app/test_handler.py
+++ b/tests/unit/app/test_handler.py
@@ -1,5 +1,5 @@
 import http
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import pytest
 from aiohttp.web import Response
@@ -12,6 +12,7 @@ from cactus_runner.models import (
     ActiveTestProcedure,
     ClientInteraction,
     ClientInteractionType,
+    Listener,
     RequestEntry,
     RunnerStatus,
     StepStatus,
@@ -121,7 +122,7 @@ async def test_proxied_request_handler_performs_authorization(mocker):
 
 
 @pytest.mark.asyncio
-async def test_proxied_request_handler(pg_empty_config, mocker):
+async def test_proxied_request_handler_before_request_trigger(pg_empty_config, mocker):
     # Arrange
     request = MagicMock()
     request.path = "/dcap"
@@ -134,18 +135,26 @@ async def test_proxied_request_handler(pg_empty_config, mocker):
         finished_zip_data=None,
         step_status={"1": StepStatus.PENDING},
     )
+    handling_listener = generate_class_instance(Listener, actions=[])
 
     handler.SERVER_URL = ""  # Override the server url
 
     handler.DEV_SKIP_AUTHORIZATION_CHECK = True
     spy_request_is_authorized = mocker.spy(handler.auth, "request_is_authorized")
 
+    # This trigger is handled by this listener
+    mock_handle_event_trigger = mocker.patch("cactus_runner.app.handler.event.handle_event_trigger")
+    mock_handle_event_trigger.return_value = [handling_listener]
+
+    mock_generate_client_request_trigger = mocker.patch(
+        "cactus_runner.app.handler.event.generate_client_request_trigger"
+    )
+    mock_trigger = MagicMock()
+    mock_generate_client_request_trigger.return_value = mock_trigger
+
     mock_proxy_request = mocker.patch("cactus_runner.app.proxy.proxy_request")
     expected_response = Response(status=200)
     mock_proxy_request.return_value = expected_response
-
-    mock_update_test_procedure_status = mocker.patch("cactus_runner.app.event.update_test_procedure_progress")
-    mock_update_test_procedure_status.return_value = (event.UNRECOGNISED_STEP_NAME, False)
 
     # Act
     response = await handler.proxied_request_handler(request=request)
@@ -165,8 +174,9 @@ async def test_proxied_request_handler(pg_empty_config, mocker):
     #  ... verify aiohttp.client.request is passed values from the request argument
     mock_proxy_request.assert_called_once()
 
-    # ... verify we called 'update_test_procedure_status'
-    mock_update_test_procedure_status.assert_called_once()
+    # ... verify we triggered the "before" handler, but not the after handler
+    mock_generate_client_request_trigger.assert_called_once_with(request, before_serving=True)
+    mock_handle_event_trigger.assert_called_once()
 
     #  ... verify we updated the request history
     request_entries = request.app[APPKEY_RUNNER_STATE].request_history
@@ -178,7 +188,80 @@ async def test_proxied_request_handler(pg_empty_config, mocker):
     assert request_entry.method == request.method
     assert_nowish(request_entry.timestamp)
     assert request_entry.status == response.status
-    assert request_entry.step_name == event.UNRECOGNISED_STEP_NAME
+    assert request_entry.step_name == handling_listener.step
+
+
+@pytest.mark.asyncio
+async def test_proxied_request_handler_after_request_trigger(pg_empty_config, mocker):
+    # Arrange
+    request = MagicMock()
+    request.path = "/dcap"
+    request.path_qs = "/dcap"
+    request.method = "GET"
+    request.app[APPKEY_RUNNER_STATE].request_history = []
+    request.app[APPKEY_RUNNER_STATE].active_test_procedure = generate_class_instance(
+        ActiveTestProcedure,
+        communications_disabled=False,
+        finished_zip_data=None,
+        step_status={"1": StepStatus.PENDING},
+    )
+    handling_listener = generate_class_instance(Listener, actions=[])
+
+    handler.SERVER_URL = ""  # Override the server url
+
+    handler.DEV_SKIP_AUTHORIZATION_CHECK = True
+    spy_request_is_authorized = mocker.spy(handler.auth, "request_is_authorized")
+
+    # This trigger is handled by this listener
+    mock_handle_event_trigger: MagicMock = mocker.patch("cactus_runner.app.handler.event.handle_event_trigger")
+    mock_handle_event_trigger.side_effect = [[], [handling_listener]]
+
+    mock_generate_client_request_trigger: MagicMock = mocker.patch(
+        "cactus_runner.app.handler.event.generate_client_request_trigger"
+    )
+    mock_before_trigger = MagicMock()
+    mock_after_trigger = MagicMock()
+    mock_generate_client_request_trigger.side_effect = [mock_before_trigger, mock_after_trigger]
+
+    mock_proxy_request = mocker.patch("cactus_runner.app.proxy.proxy_request")
+    expected_response = Response(status=200)
+    mock_proxy_request.return_value = expected_response
+
+    # Act
+    response = await handler.proxied_request_handler(request=request)
+
+    # Assert
+    #  ... verify we skip authorization
+    assert spy_request_is_authorized.call_count == 0
+
+    #  ... verify we update the last client interaction
+    assert isinstance(request.app[APPKEY_RUNNER_STATE].last_client_interaction, ClientInteraction)
+    assert (
+        request.app[APPKEY_RUNNER_STATE].last_client_interaction.interaction_type
+        == ClientInteractionType.PROXIED_REQUEST
+    )
+    assert_nowish(request.app[APPKEY_RUNNER_STATE].last_client_interaction.timestamp)
+
+    #  ... verify aiohttp.client.request is passed values from the request argument
+    mock_proxy_request.assert_called_once()
+
+    # ... verify we triggered the "before" handler, but not the after handler
+    mock_generate_client_request_trigger.assert_has_calls(
+        [call(request, before_serving=True), call(request, before_serving=False)]
+    )
+    mock_handle_event_trigger.call_count == 2
+
+    #  ... verify we updated the request history
+    request_entries = request.app[APPKEY_RUNNER_STATE].request_history
+    assert len(request_entries) == 1
+    request_entry = request_entries[0]
+    assert isinstance(request_entry, RequestEntry)
+    assert request_entry.url == request.path_qs
+    assert request_entry.path == request.path
+    assert request_entry.method == request.method
+    assert_nowish(request_entry.timestamp)
+    assert request_entry.status == response.status
+    assert request_entry.step_name == handling_listener.step
 
 
 @pytest.mark.asyncio

--- a/tests/unit/app/test_handler.py
+++ b/tests/unit/app/test_handler.py
@@ -6,7 +6,7 @@ from aiohttp.web import Response
 from assertical.asserts.time import assert_nowish
 from assertical.fake.generator import generate_class_instance
 
-from cactus_runner.app import event, handler
+from cactus_runner.app import handler
 from cactus_runner.app.shared import APPKEY_RUNNER_STATE
 from cactus_runner.models import (
     ActiveTestProcedure,


### PR DESCRIPTION
* Events are now triggered by inspecting a new "EventTrigger" that handlers can generate
* There is a unified `is_listener_triggerable` for matching an EventTrigger to a Listener
* events now don't update the runner_state - That responsibility has been moved to actions
