### PR TITLE
Storage extensions for check_readings_der_stored_energy

### DIFF
--- a/src/cactus_runner/app/envoy_common.py
+++ b/src/cactus_runner/app/envoy_common.py
@@ -42,6 +42,7 @@ async def get_csip_aus_site_reading_types(
     session: AsyncSession,
     uom: UomType,
     location: ReadingLocation,
+    kind: KindType,
     qualifier: DataQualifierType = DataQualifierType.AVERAGE,
 ) -> Sequence[SiteReadingType]:
     """Finds all SiteReadingTypes (MirrorUsagePoints) for the active site that matches the CSIP-Aus requirements for
@@ -57,6 +58,8 @@ async def get_csip_aus_site_reading_types(
     UomType.REACTIVE_POWER_VAR = MANDATORY
     UomType.FREQUENCY_HZ = OPTIONAL
     UomType.VOLTAGE = MANDATORY (at least 1 site or voltage MUP is required)
+    UomType.REAL_ENERGY_WATT_HOUR = MANDATORY (for 1.3 storage extensions)
+
 
     qualifier will filter the returned DataQualifierType - certain types are optional/mandatory under CSIP-Aus
 
@@ -64,6 +67,8 @@ async def get_csip_aus_site_reading_types(
     DataQualifierType.NORMAL = OPTIONAL
     DataQualifierType.MINIMUM = OPTIONAL
     DataQualifierType.MAXIMUM = OPTIONAL
+    DataQualifierType.INSTANTANEOUS = OPTIONAL (for 1.3 storage extensions)
+
 
     Returns the list of all SiteReadingType's that meet this criteria. Expect multiple if multiple phases or
     accumulation behaviors are being reported."""
@@ -77,7 +82,7 @@ async def get_csip_aus_site_reading_types(
             (SiteReadingType.site_id == site.site_id)
             & (SiteReadingType.role_flags == location)
             & (SiteReadingType.uom == uom)
-            & (SiteReadingType.kind == KindType.POWER)
+            & (SiteReadingType.kind == kind)
             & (SiteReadingType.data_qualifier == qualifier)
         )
         .order_by(SiteReadingType.created_time.asc())

--- a/tests/unit/app/test_envoy_common.py
+++ b/tests/unit/app/test_envoy_common.py
@@ -52,7 +52,7 @@ async def test_get_active_site_many_sites(pg_base_config):
 async def test_get_csip_aus_site_reading_types_no_sites(pg_base_config):
     async with generate_async_session(pg_base_config) as session:
         result = await get_csip_aus_site_reading_types(
-            session, UomType.REAL_POWER_WATT, ReadingLocation.SITE_READING, DataQualifierType.AVERAGE
+            session, UomType.REAL_POWER_WATT, ReadingLocation.SITE_READING, KindType.POWER, DataQualifierType.AVERAGE
         )
         assert_list_type(SiteReadingType, result, count=0)
 
@@ -65,7 +65,7 @@ async def test_get_csip_aus_site_reading_types_no_mups(pg_base_config):
 
     async with generate_async_session(pg_base_config) as session:
         result = await get_csip_aus_site_reading_types(
-            session, UomType.REAL_POWER_WATT, ReadingLocation.SITE_READING, DataQualifierType.AVERAGE
+            session, UomType.REAL_POWER_WATT, ReadingLocation.SITE_READING, KindType.POWER, DataQualifierType.AVERAGE
         )
         assert_list_type(SiteReadingType, result, count=0)
 
@@ -155,14 +155,44 @@ async def test_get_csip_aus_site_reading_types_many_mups(pg_base_config):
                 role_flags=ReadingLocation.DEVICE_READING | RoleFlagsType.IS_DC,
             )
         )  # wrong role flags
+        # Storage extension
+        session.add(
+            generate_class_instance(
+                SiteReadingType,
+                seed=808,
+                aggregator_id=1,
+                site_reading_type_id=7,
+                site=site2,
+                uom=UomType.REAL_ENERGY_WATT_HOURS,
+                data_qualifier=DataQualifierType.NOT_APPLICABLE,
+                kind=KindType.ENERGY,
+                role_flags=ReadingLocation.DEVICE_READING,
+            )
+        )  # Valid
+
         await session.commit()
 
     async with generate_async_session(pg_base_config) as session:
         result = await get_csip_aus_site_reading_types(
-            session, UomType.REAL_POWER_WATT, ReadingLocation.DEVICE_READING, DataQualifierType.AVERAGE
+            session=session,
+            uom=UomType.REAL_POWER_WATT,
+            location=ReadingLocation.DEVICE_READING,
+            kind=KindType.POWER,
+            qualifier=DataQualifierType.AVERAGE,
         )
         assert [2, 4] == [srt.site_reading_type_id for srt in result]
         assert_list_type(SiteReadingType, result, count=2)
+
+        # Storage extension
+        result = await get_csip_aus_site_reading_types(
+            session=session,
+            uom=UomType.REAL_ENERGY_WATT_HOURS,
+            location=ReadingLocation.DEVICE_READING,
+            kind=KindType.ENERGY,
+            qualifier=DataQualifierType.NOT_APPLICABLE,
+        )
+        assert [7] == [srt.site_reading_type_id for srt in result]
+        assert_list_type(SiteReadingType, result, count=1)
 
 
 @pytest.mark.anyio
@@ -196,7 +226,18 @@ async def test_get_site_readings(pg_base_config):
             kind=KindType.POWER,
             role_flags=ReadingLocation.DEVICE_READING,
         )
-        session.add_all([power, voltage])
+        energy = generate_class_instance(
+            SiteReadingType,
+            seed=404,
+            aggregator_id=1,
+            site_reading_type_id=3,
+            site=site1,
+            uom=UomType.REAL_ENERGY_WATT_HOURS,
+            data_qualifier=DataQualifierType.NOT_APPLICABLE,
+            kind=KindType.ENERGY,
+            role_flags=ReadingLocation.DEVICE_READING,
+        )
+        session.add_all([power, voltage, energy])
 
         # Add readings
         def gen_sr(seed: int, srt: SiteReadingType) -> SiteReading:
@@ -211,21 +252,45 @@ async def test_get_site_readings(pg_base_config):
         voltage_readings = [gen_sr(i + num_power_readings, voltage) for i in range(1, num_voltage_readings + 1)]
         session.add_all(voltage_readings)
 
+        num_energy_readings = 7
+        energy_readings = [
+            gen_sr(i + num_power_readings + num_voltage_readings, energy) for i in range(1, num_energy_readings + 1)
+        ]
+        session.add_all(energy_readings)
+
         await session.commit()
 
     async with generate_async_session(pg_base_config) as session:
         power_type, *_ = await get_csip_aus_site_reading_types(
-            session, UomType.REAL_POWER_WATT, ReadingLocation.DEVICE_READING, DataQualifierType.AVERAGE
+            session=session,
+            uom=UomType.REAL_POWER_WATT,
+            location=ReadingLocation.DEVICE_READING,
+            kind=KindType.POWER,
+            qualifier=DataQualifierType.AVERAGE,
         )
 
         power_readings = await get_site_readings(session=session, site_reading_type=power_type)
         assert_list_type(SiteReading, power_readings, count=num_power_readings)
 
         voltage_type, *_ = await get_csip_aus_site_reading_types(
-            session, UomType.VOLTAGE, ReadingLocation.DEVICE_READING, DataQualifierType.AVERAGE
+            session=session,
+            uom=UomType.VOLTAGE,
+            location=ReadingLocation.DEVICE_READING,
+            kind=KindType.POWER,
+            qualifier=DataQualifierType.AVERAGE,
         )
         voltage_readings = await get_site_readings(session=session, site_reading_type=voltage_type)
         assert_list_type(SiteReading, voltage_readings, count=num_voltage_readings)
+
+        energy_type, *_ = await get_csip_aus_site_reading_types(
+            session=session,
+            uom=UomType.REAL_ENERGY_WATT_HOURS,
+            location=ReadingLocation.DEVICE_READING,
+            kind=KindType.ENERGY,
+            qualifier=DataQualifierType.NOT_APPLICABLE,
+        )
+        energy_readings = await get_site_readings(session=session, site_reading_type=energy_type)
+        assert_list_type(SiteReading, energy_readings, count=num_energy_readings)
 
 
 @pytest.mark.anyio
@@ -259,7 +324,18 @@ async def test_get_reading_counts_grouped_by_reading_type(pg_base_config):
             kind=KindType.POWER,
             role_flags=ReadingLocation.DEVICE_READING,
         )
-        session.add_all([power, voltage])
+        energy = generate_class_instance(
+            SiteReadingType,
+            seed=404,
+            aggregator_id=1,
+            site_reading_type_id=3,
+            site=site1,
+            uom=UomType.REAL_ENERGY_WATT_HOURS,
+            data_qualifier=DataQualifierType.NOT_APPLICABLE,
+            kind=KindType.ENERGY,
+            role_flags=ReadingLocation.DEVICE_READING,
+        )
+        session.add_all([power, voltage, energy])
 
         # Add readings
         def gen_sr(seed: int, srt: SiteReadingType) -> SiteReading:
@@ -274,17 +350,39 @@ async def test_get_reading_counts_grouped_by_reading_type(pg_base_config):
         voltage_readings = [gen_sr(i + num_power_readings, voltage) for i in range(1, num_voltage_readings + 1)]
         session.add_all(voltage_readings)
 
+        num_energy_readings = 7
+        energy_readings = [
+            gen_sr(i + num_power_readings + num_voltage_readings, energy) for i in range(1, num_energy_readings + 1)
+        ]
+        session.add_all(energy_readings)
+
         await session.commit()
 
     async with generate_async_session(pg_base_config) as session:
         power_type, *_ = await get_csip_aus_site_reading_types(
-            session, UomType.REAL_POWER_WATT, ReadingLocation.DEVICE_READING, DataQualifierType.AVERAGE
+            session=session,
+            uom=UomType.REAL_POWER_WATT,
+            location=ReadingLocation.DEVICE_READING,
+            kind=KindType.POWER,
+            qualifier=DataQualifierType.AVERAGE,
         )
         voltage_type, *_ = await get_csip_aus_site_reading_types(
-            session, UomType.VOLTAGE, ReadingLocation.DEVICE_READING, DataQualifierType.AVERAGE
+            session=session,
+            uom=UomType.VOLTAGE,
+            location=ReadingLocation.DEVICE_READING,
+            kind=KindType.POWER,
+            qualifier=DataQualifierType.AVERAGE,
+        )
+        energy_type, *_ = await get_csip_aus_site_reading_types(
+            session=session,
+            uom=UomType.REAL_ENERGY_WATT_HOURS,
+            location=ReadingLocation.DEVICE_READING,
+            kind=KindType.ENERGY,
+            qualifier=DataQualifierType.NOT_APPLICABLE,
         )
         count_by_reading_type = await get_reading_counts_grouped_by_reading_type(session)
 
-        assert len(count_by_reading_type) == 2  # two reading types (voltage and power)
+        assert len(count_by_reading_type) == 3  # three reading types (voltage, power and energy)
         assert count_by_reading_type[power_type] == num_power_readings
         assert count_by_reading_type[voltage_type] == num_voltage_readings
+        assert count_by_reading_type[energy_type] == num_energy_readings

--- a/tests/unit/app/test_readings.py
+++ b/tests/unit/app/test_readings.py
@@ -72,12 +72,23 @@ async def test_get_readings(mocker, pg_base_config):
             kind=KindType.POWER,
             role_flags=ReadingLocation.SITE_READING,
         )
-        session.add_all([power, voltage, reactive])
+        energy = generate_class_instance(
+            SiteReadingType,
+            seed=505,
+            aggregator_id=1,
+            site_reading_type_id=4,
+            site=site1,
+            uom=UomType.REAL_ENERGY_WATT_HOURS,
+            data_qualifier=DataQualifierType.NOT_APPLICABLE,
+            kind=KindType.ENERGY,
+            role_flags=ReadingLocation.DEVICE_READING,
+        )
+        session.add_all([power, voltage, reactive, energy])
 
         # Add readings
         def gen_sr(seed: int, srt: SiteReadingType) -> SiteReading:
             """Shorthand for generating a new SiteReading with the specified type"""
-            return generate_class_instance(SiteReading, seed=seed, site_reading_type=srt)
+            return generate_class_instance(SiteReading, seed=seed, site_reading_type=srt, site_reading_id=None)
 
         num_power_readings = 5
         power_readings = [gen_sr(i, power) for i in range(1, num_power_readings + 1)]
@@ -87,6 +98,10 @@ async def test_get_readings(mocker, pg_base_config):
         voltage_readings = [gen_sr(i + num_power_readings, voltage) for i in range(1, num_voltage_readings + 1)]
         session.add_all(voltage_readings)
 
+        num_energy_readings = 1
+        energy_readings = [gen_sr(i + num_energy_readings, energy) for i in range(1, num_energy_readings + 1)]
+        session.add_all(energy_readings)
+
         await session.commit()
 
     session = generate_async_session(pg_base_config)
@@ -94,9 +109,30 @@ async def test_get_readings(mocker, pg_base_config):
     mock_begin_session.__aenter__.return_value = session
 
     reading_specifiers = [
-        ReadingSpecifier(uom=UomType.REAL_POWER_WATT, location=ReadingLocation.DEVICE_READING),
-        ReadingSpecifier(uom=UomType.VOLTAGE, location=ReadingLocation.SITE_READING),
-        ReadingSpecifier(uom=UomType.REACTIVE_POWER_VAR, location=ReadingLocation.SITE_READING),
+        ReadingSpecifier(
+            uom=UomType.REAL_POWER_WATT,
+            location=ReadingLocation.DEVICE_READING,
+            kind=KindType.POWER,
+            qualifier=DataQualifierType.AVERAGE,
+        ),
+        ReadingSpecifier(
+            uom=UomType.VOLTAGE,
+            location=ReadingLocation.SITE_READING,
+            kind=KindType.POWER,
+            qualifier=DataQualifierType.AVERAGE,
+        ),
+        ReadingSpecifier(
+            uom=UomType.REACTIVE_POWER_VAR,
+            location=ReadingLocation.SITE_READING,
+            kind=KindType.POWER,
+            qualifier=DataQualifierType.AVERAGE,
+        ),
+        ReadingSpecifier(
+            uom=UomType.REAL_ENERGY_WATT_HOURS,
+            location=ReadingLocation.DEVICE_READING,
+            kind=KindType.ENERGY,
+            qualifier=DataQualifierType.NOT_APPLICABLE,
+        ),
     ]
 
     # Act
@@ -104,8 +140,10 @@ async def test_get_readings(mocker, pg_base_config):
     readings_map = await get_readings(reading_specifiers=reading_specifiers)
 
     # Assert
-    assert_dict_type(SiteReadingType, DataFrame, readings_map, count=2)  # two reading types with data (voltage, power)
-    assert sorted([num_power_readings, num_voltage_readings]) == sorted(
+    assert_dict_type(
+        SiteReadingType, DataFrame, readings_map, count=3
+    )  # three reading types with data (voltage, power, energy)
+    assert sorted([num_power_readings, num_voltage_readings, num_energy_readings]) == sorted(
         [len(readings) for readings in readings_map.values()]
     )
 


### PR DESCRIPTION
* Contains check_readings_der_stored_energy and associated downstream updates to readings/envoy_common
* Includes unit tests


Manually lifted from https://github.com/synergy-au/cactus-runner - Should be pretty close to a manual merge (only a few minor deviations)