### PR TITLE
Feature/pen

### DIFF
--- a/src/cactus_runner/app/handler.py
+++ b/src/cactus_runner/app/handler.py
@@ -229,13 +229,13 @@ async def init_handler(request: web.Request):  # noqa: C901
     else:
         logger.info(f"run ID {run_id} has been assigned to this test.")
 
-    pen = request.query.get("pen", None)
-    if pen is None:
+    raw_pen = request.query.get("pen", None)
+    if raw_pen is None:
         logger.info("No PEN has been associated with this test. Defaulting to 0 (no PEN)")
         pen = 0
     else:
         try:
-            pen = int(pen)
+            pen = int(raw_pen)
             logger.info(f"PEN {pen} has been associated with this test")
         except ValueError:
             logger.error("A non-numeric PEN value was supplied: {pen}. Defaulting to 0 (no PEN)")

--- a/src/cactus_runner/app/handler.py
+++ b/src/cactus_runner/app/handler.py
@@ -149,6 +149,7 @@ async def init_handler(request: web.Request):  # noqa: C901
             query parameters:
             'test' - the name of the test procedure to initialize
             'certificate' - the PEM encoded certificate to register as belonging to the aggregator
+            'pen' - the Private Enterprise Number (PEN)
             'subscription_domain' - [Optional] the FQDN to be added to the pub/sub allow list for subscriptions
 
         Returns:
@@ -228,6 +229,18 @@ async def init_handler(request: web.Request):  # noqa: C901
     else:
         logger.info(f"run ID {run_id} has been assigned to this test.")
 
+    pen = request.query.get("pen", None)
+    if pen is None:
+        logger.info("No PEN has been associated with this test. Defaulting to 0 (no PEN)")
+        pen = 0
+    else:
+        try:
+            pen = int(pen)
+            logger.info(f"PEN {pen} has been associated with this test")
+        except ValueError:
+            logger.error("A non-numeric PEN value was supplied: {pen}. Defaulting to 0 (no PEN)")
+            pen = 0
+
     # Need EITHER device certificate or an aggregator certificate. Can't run both.
     if device_lfdi is not None and aggregator_lfdi is not None:
         return web.Response(
@@ -286,6 +299,7 @@ async def init_handler(request: web.Request):  # noqa: C901
         client_aggregator_id=client_aggregator_id,
         client_certificate_type=client_type,
         run_id=run_id,
+        pen=pen,
     )
 
     logger.info(

--- a/src/cactus_runner/client/__init__.py
+++ b/src/cactus_runner/client/__init__.py
@@ -57,18 +57,20 @@ class RunnerClient:
         device_certificate: str | None,
         subscription_domain: str | None = None,
         run_id: str | None = None,
+        pen: int = 0,
     ) -> InitResponseBody:
         """
         Args:
             test_id: The TestProcedureId to initialise the runner with
             csip_aus_version: What CSIP Aus version of envoy is this runner communicating with?
             aggregator_certificate: The PEM encoded public certificate to be installed as the "aggregator" cert
+            pen: The IANA-registered private enterprise number (PEN). Defaults to 0 (no PEN supplied).
             device_certificate: The PEM encoded public certificate to be reserved for use by a "device"
             subscription_domain: The FQDN that will be added to the allow list for subscription notifications
             run_id: The upstream identifier for this run (to be used in report metadata)"""
 
         try:
-            params = {"test": test_id.value, "csip_aus_version": csip_aus_version.value}
+            params = {"test": test_id.value, "csip_aus_version": csip_aus_version.value, "pen": pen}
             if aggregator_certificate is not None:
                 params["aggregator_certificate"] = aggregator_certificate
             if device_certificate is not None:

--- a/src/cactus_runner/models.py
+++ b/src/cactus_runner/models.py
@@ -40,6 +40,7 @@ class ActiveTestProcedure:
     client_lfdi: str  # The LFDI of the client certificate expected for the test (Either aggregator or device client)
     client_sfdi: int  # The SFDI of the client certificate expected for the test (Either aggregator or device client)
     run_id: str | None  # Metadata about what "id" has been assigned to this test (from external) - if any
+    pen: int  # Private Enterprise Number (PEN). A value of 0 means no valid PEN avaiable.
     communications_disabled: bool = False
     finished_zip_data: bytes | None = (
         None  # Finalised ZIP file. If not None - this test is "done" and shouldn't update any events/state


### PR DESCRIPTION
Add support for,
- Receiving a Private Enterprise Number (PEN) during init from orchestrator
- verifying aggregator lfdi matches PEN (end-device-contents check)
- verifying site reading mrid and group_mrid matches PEN (readings checks)