### PR TITLE
Adds extra info to pdf

### DIFF
--- a/src/cactus_runner/app/reporting.py
+++ b/src/cactus_runner/app/reporting.py
@@ -20,7 +20,12 @@ from envoy.server.model import (
     SiteDERStatus,
 )
 from envoy.server.model.site_reading import SiteReadingType
-from envoy_schema.server.schema.sep2.types import DataQualifierType, PhaseCode, UomType
+from envoy_schema.server.schema.sep2.types import (
+    DataQualifierType,
+    DeviceCategory,
+    PhaseCode,
+    UomType,
+)
 from reportlab.lib.colors import Color, HexColor
 from reportlab.lib.pagesizes import A4
 from reportlab.lib.styles import (
@@ -34,6 +39,7 @@ from reportlab.platypus import (
     BaseDocTemplate,
     Flowable,
     Image,
+    KeepTogether,
     Paragraph,
     SimpleDocTemplate,
     Spacer,
@@ -239,6 +245,7 @@ def generate_overview_section(
     start_timestamp: datetime,
     client_cert_type: ClientCertificateType,
     client_lfdi: str,
+    client_pen: int,
     duration: timedelta,
     stylesheet: StyleSheet,
 ) -> list[Flowable]:
@@ -247,7 +254,7 @@ def generate_overview_section(
     elements.append(Paragraph(test_procedure_description, style=stylesheet.subheading))
     elements.append(stylesheet.spacer)
 
-    doe_data = [
+    overview_data = [
         [
             "Run ID",
             test_run_id,
@@ -262,10 +269,16 @@ def generate_overview_section(
             "Start time (UTC)",
             start_timestamp.strftime(stylesheet.date_format),
         ],
-        ["", "", "", "Duration", str(duration).split(".")[0]],  # remove microseconds from output
+        [
+            "PEN",
+            str(client_pen) if client_pen else "Not supplied",
+            "",
+            "Duration",
+            str(duration).split(".")[0],
+        ],  # remove microseconds from output
     ]
     column_widths = [int(fraction * stylesheet.table_width) for fraction in [0.15, 0.4, 0.05, 0.2, 0.2]]
-    table = Table(doe_data, colWidths=column_widths)
+    table = Table(overview_data, colWidths=column_widths)
     tstyle = TableStyle(
         [
             ("BACKGROUND", (0, 0), (1, 2), OVERVIEW_BACKGROUND),
@@ -281,6 +294,13 @@ def generate_overview_section(
     )
     table.setStyle(tstyle)
     elements.append(table)
+    if client_cert_type is ClientCertificateType.DEVICE:
+        elements.append(
+            Paragraph(
+                "The device LFDI is the LFDI encoded in the certificate used for authentication, not be confused with the LFDI of any devices registered during this test procedure.",  # noqa 501
+                style=ParagraphStyle(name="TableNote", fontSize=6),
+            )
+        )
     elements.append(stylesheet.spacer)
     return elements
 
@@ -803,17 +823,69 @@ def generate_site_der_status_table(site_der_status: SiteDERStatus, stylesheet: S
     return elements
 
 
+def device_category_to_string(device_category: DeviceCategory) -> str:
+    if device_category == 0:
+        return "Unspecified device category (0)"
+    flags = [flag.replace("_", " ").lower() for flag in repr(device_category).split(".")[1].split(":")[0].split("|")]
+    return " | ".join(flags)
+
+
+def generate_device_overview_table(
+    site: Site,
+    generation_method: str,
+    stylesheet: StyleSheet,
+) -> list[Flowable]:
+    elements: list[Flowable] = []
+
+    # Convert device category to a useful string
+    device_data = [
+        [
+            "NMI",
+            site.nmi if site.nmi else "Unspecified",
+        ],
+        [
+            "LFDI",
+            site.lfdi,
+        ],
+        [
+            "Device Category",
+            device_category_to_string(device_category=DeviceCategory(site.device_category)),
+        ],
+        [
+            "Site Generation",
+            generation_method,
+        ],
+    ]
+    column_widths = [int(fraction * stylesheet.table_width) for fraction in [0.2, 0.5]]
+    table = Table(device_data, colWidths=column_widths)
+    tstyle = TableStyle(
+        [
+            ("BACKGROUND", (0, 0), (-1, -1), OVERVIEW_BACKGROUND),
+            ("TEXTCOLOR", (0, 0), (-1, -1), TABLE_TEXT_COLOR),
+            ("ALIGN", (0, 0), (-1, -1), "LEFT"),
+            ("FONTSIZE", (0, 0), (-1, -1), 8),
+            ("FONTNAME", (0, 0), (0, -1), "Helvetica-Bold"),
+        ]
+    )
+    table.setStyle(tstyle)
+    elements.append(KeepTogether(table))
+    return elements
+
+
 def generate_site_section(site: Site, stylesheet: StyleSheet) -> list[Flowable]:
     elements: list[Flowable] = []
 
     if site.nmi:
         section_title = f"EndDevice {site.site_id} (nmi: {site.nmi})"
-        site_description = f"Created at {site.created_time.strftime(stylesheet.date_format)}"
+        generation_method = f"Created at {site.created_time.strftime(stylesheet.date_format)}"
     else:
         section_title = f"EndDevice {site.site_id}"
-        site_description = "Generated as part of test procedure precondition."
+        generation_method = "Generated as part of test procedure precondition."
     elements.append(Paragraph(section_title, stylesheet.subheading))
-    elements.append(Paragraph(site_description))
+    elements.append(stylesheet.spacer)
+    elements.extend(
+        generate_device_overview_table(site=site, generation_method=generation_method, stylesheet=stylesheet)
+    )
     elements.append(stylesheet.spacer)
     if site.site_ders:
         site_der = site.site_ders[0]
@@ -1058,6 +1130,7 @@ def generate_page_elements(
                 start_timestamp=start_timestamp,
                 client_lfdi=active_test_procedure.client_lfdi,
                 client_cert_type=active_test_procedure.client_certificate_type,
+                client_pen=active_test_procedure.pen,
                 duration=duration,
                 stylesheet=stylesheet,
             )

--- a/tests/integration/test_all_01.py
+++ b/tests/integration/test_all_01.py
@@ -70,7 +70,7 @@ async def test_all_01_full(cactus_runner_client: TestClient, certificate_type: s
         for filename in filenames:
             if filename.startswith(prefix):
                 return filename
-        return ""
+        raise Exception(f"No filename prefixed by '{prefix}' found in filenames.")
 
     summary_data = zip.read(get_filename(prefix="CactusTestProcedureSummary", filenames=zip.namelist()))
     assert len(summary_data) > 0

--- a/tests/unit/app/test_reporting.py
+++ b/tests/unit/app/test_reporting.py
@@ -2,12 +2,14 @@ from datetime import datetime, timezone
 from decimal import Decimal
 
 import pandas as pd
+import pytest
 from assertical.fake.generator import generate_class_instance
 from cactus_test_definitions import TestProcedureConfig
 from envoy.server.model import DynamicOperatingEnvelope, Site, SiteReadingType
+from envoy_schema.server.schema.sep2.types import DeviceCategory
 
 from cactus_runner.app.check import CheckResult
-from cactus_runner.app.reporting import pdf_report_as_bytes
+from cactus_runner.app.reporting import device_category_to_string, pdf_report_as_bytes
 from cactus_runner.models import (
     ActiveTestProcedure,
     RequestEntry,
@@ -107,3 +109,15 @@ def test_pdf_report_as_bytes_does_raise_exception_for_large_amount_of_validation
     )
 
     # There should be not exceptions raises do to Flowables being too large
+
+
+@pytest.mark.parametrize(
+    "device_category,expected",
+    [
+        (DeviceCategory(0), "Unspecified device category (0)"),
+        (DeviceCategory.SMART_ENERGY_MODULE, "smart energy module"),
+        (DeviceCategory.SMART_ENERGY_MODULE | DeviceCategory.WATER_HEATER, "water heater | smart energy module"),
+    ],
+)
+def test_device_category_to_string(device_category: DeviceCategory, expected: str):
+    assert device_category_to_string(device_category=device_category) == expected


### PR DESCRIPTION
Adds the following information to the pdf report

- The PEN (overview section)
- An explanation of the certificate device LFDI beneath the overview section if the cert is a device cert.
- A table of useful enddevice values including the device's LFDI

Example overview:
<img width="1062" height="150" alt="Screenshot from 2025-09-02 11-19-02" src="https://github.com/user-attachments/assets/4944eeab-0f8d-46e5-801b-64186f265371" />

Example enddevice section:
<img width="765" height="171" alt="Screenshot from 2025-09-02 11-19-39" src="https://github.com/user-attachments/assets/8071149e-7a25-4ccf-9277-56e34224d455" />
