### PR TITLE
feat: added the encapsulation of resolved parameters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ docs = ["sphinx"]
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "-ra -q"
+addopts = "-ra -q -v"
 testpaths = ["tests"]
 asyncio_default_fixture_loop_scope = "session"
 markers = [

--- a/src/cactus_runner/app/action.py
+++ b/src/cactus_runner/app/action.py
@@ -346,8 +346,8 @@ async def apply_action(
     if not active_test_procedure:
         return
 
-    resolved_parameters = await resolve_variable_expressions_from_parameters(session, action.parameters)
-
+    resolved_with_metadata_parameters = await resolve_variable_expressions_from_parameters(session, action.parameters)
+    resolved_parameters = {k: v.value for k, v in resolved_with_metadata_parameters.items()}
     logger.info(f"Executing action {action} with parameters {resolved_parameters}")
     try:
         match action.type:

--- a/src/cactus_runner/app/check.py
+++ b/src/cactus_runner/app/check.py
@@ -406,7 +406,7 @@ async def check_der_settings_contents(
             # A boolean expression was evaluated for this field and potentially failed
             do_field_boolean_expression_evaluated_check(soft_checker, der_settings, field, ogl_exp)
         elif isinstance(raw_value, bool):
-            # A set/unset check 
+            # A set/unset check
             do_field_exists_check(soft_checker, der_settings, field, raw_value)
 
     return soft_checker.finalize()

--- a/src/cactus_runner/app/check.py
+++ b/src/cactus_runner/app/check.py
@@ -9,6 +9,7 @@ import pydantic
 import pydantic.alias_generators
 import pydantic.fields
 from cactus_test_definitions.client import Check
+from cactus_test_definitions import variable_expressions
 from envoy.server.crud.common import convert_lfdi_to_sfdi
 from envoy.server.exception import InvalidMappingError
 from envoy.server.mapper.sep2.pub_sub import SubscriptionMapper
@@ -35,6 +36,7 @@ from cactus_runner.app.envoy_common import (
 )
 from cactus_runner.app.evaluator import (
     resolve_variable_expressions_from_parameters,
+    ResolvedParam,
 )
 from cactus_runner.models import ActiveTestProcedure, ClientCertificateType
 
@@ -274,6 +276,50 @@ async def check_end_device_contents(
     return CheckResult(True, None)
 
 
+def do_field_boolean_expression_evaluated_check(
+    soft_checker: SoftChecker,
+    db_entity: SiteDERSetting | SiteDERRating,
+    field: pydantic.fields.FieldInfo,
+    original_expression: variable_expressions.BaseExpression,
+) -> None:
+    """Checks that a boolean expression is appropriately evaluated for a field within a specified database entity.
+
+    Depends on the type annotation having a SiteReadingTypeProperty ot allow the mapping of field to a specific property
+    in db_entity.
+
+    Args:
+        soft_checker: Object for holding errors from the check
+        db_entity: The object whose properties are interrogated
+        field: The field info with Annotated metadata containing a SiteReadingTypeProperty. If not metadata - no check
+        original_expression: The expression that the evaluation occurred on
+    """
+    if not field.metadata:
+        # If we don't have metadata - nothing we can check
+        return
+
+    property: SiteReadingTypeProperty | None = None
+    for m in field.metadata:
+        if isinstance(m, SiteReadingTypeProperty):
+            property = m
+            break
+
+    if property is None:
+        # If we don't have metadata - nothing we can check
+        return
+
+    actual_value = getattr(db_entity, property.name, None)
+    if actual_value is None:
+        soft_checker.add(
+            f"{field.alias} must satisfy expression '{original_expression.expression_representation()}' "
+            "but is currently not set"
+        )
+    else:
+        soft_checker.add(
+            f"{field.alias} must satisfy expression '{original_expression.expression_representation()}' "
+            f"but is currently set as: {actual_value}"
+        )
+
+
 def do_field_exists_check(
     soft_checker: SoftChecker,
     db_entity: SiteDERSetting | SiteDERRating,
@@ -304,12 +350,14 @@ def do_field_exists_check(
 
     actual_value = getattr(db_entity, property.name, None)
     if expected_to_be_set and actual_value is None:
-        soft_checker.add(f"{field.alias} MUST be set but is currently missing.")
+        soft_checker.add(f"{field.alias} MUST be set but is currently missing")
     elif not expected_to_be_set and actual_value is not None:
-        soft_checker.add(f"{field.alias} MUST be unset but is currently specified as: {actual_value}.")
+        soft_checker.add(f"{field.alias} MUST be unset but is currently specified as: {actual_value}")
 
 
-async def check_der_settings_contents(session: AsyncSession, resolved_parameters: dict[str, Any]) -> CheckResult:
+async def check_der_settings_contents(
+    session: AsyncSession, resolved_parameters: dict[str, ResolvedParam]
+) -> CheckResult:
     """Implements the der-settings-contents check
 
     Returns pass if DERSettings has been submitted for the active site"""
@@ -326,7 +374,7 @@ async def check_der_settings_contents(session: AsyncSession, resolved_parameters
         return CheckResult(False, f"No DERSetting found for EndDevice {site.site_id}.")
 
     # Validate and return model instance
-    params = ParamsDERSettingsContents.model_validate(resolved_parameters)
+    params = ParamsDERSettingsContents.model_validate({k: v.value for k, v in resolved_parameters.items()})
 
     # Create soft checker for parameter checks
     soft_checker = SoftChecker()
@@ -334,6 +382,7 @@ async def check_der_settings_contents(session: AsyncSession, resolved_parameters
     # Perform parameter checks
     for k in params.model_fields_set:
         raw_value: Any = getattr(params, k)
+        field = params.__pydantic_fields__[k]
         if k == "set_grad_w" and der_settings.grad_w != params.set_grad_w:
             soft_checker.add(f"DERSetting.setGradW {der_settings.grad_w} doesn't match expected {params.set_grad_w}")
         elif k in ["doe_modes_enabled_set", "modes_enabled_set"]:
@@ -348,14 +397,24 @@ async def check_der_settings_contents(session: AsyncSession, resolved_parameters
             if (getattr(der_settings, k.rstrip("_unset")) & params_val) != 0:
                 field = params.__pydantic_fields__[k]
                 soft_checker.add(f"DERSetting.{field.alias} minimum flag setting check lo (==0) failed")
+        elif (
+            raw_value is False
+            and field.alias is not None
+            and resolved_parameters.get(field.alias) is not None
+            and (ogl_exp := resolved_parameters[field.alias].original_expression) is not None
+        ):
+            # A boolean expression was evaluated for this field and potentially failed
+            do_field_boolean_expression_evaluated_check(soft_checker, der_settings, field, ogl_exp)
         elif isinstance(raw_value, bool):
-            field = params.__pydantic_fields__[k]
+            # A set/unset check 
             do_field_exists_check(soft_checker, der_settings, field, raw_value)
 
     return soft_checker.finalize()
 
 
-async def check_der_capability_contents(session: AsyncSession, resolved_parameters: dict[str, Any]) -> CheckResult:
+async def check_der_capability_contents(
+    session: AsyncSession, resolved_parameters: dict[str, ResolvedParam]
+) -> CheckResult:
     """Implements the der-capability-contents check
 
     Returns pass if DERCapability has been submitted for the active site"""
@@ -372,7 +431,7 @@ async def check_der_capability_contents(session: AsyncSession, resolved_paramete
         return CheckResult(False, f"No DERCapability found for EndDevice {site.site_id}.")
 
     # Validate and return model instance
-    params = ParamsDERCapabilityContents.model_validate(resolved_parameters)
+    params = ParamsDERCapabilityContents.model_validate({k: v.value for k, v in resolved_parameters.items()})
 
     # Create soft checker for parameter checks
     soft_checker = SoftChecker()
@@ -380,6 +439,7 @@ async def check_der_capability_contents(session: AsyncSession, resolved_paramete
     # Perform parameter checks
     for k in params.model_fields_set:
         raw_value: Any = getattr(params, k)
+        field = params.__pydantic_fields__[k]
         if k in ["doe_modes_supported_set", "modes_supported_set"]:
             # Bitwise-and checks
             params_val = int(raw_value, 16)
@@ -393,8 +453,15 @@ async def check_der_capability_contents(session: AsyncSession, resolved_paramete
             if (getattr(der_rating, k.rstrip("_unset")) & params_val) != 0:
                 field = params.__pydantic_fields__[k]
                 soft_checker.add(f"DERCapability.{field.alias} minimum flag setting check lo (==0) failed")
+        elif (
+            raw_value is False
+            and field.alias is not None
+            and resolved_parameters.get(field.alias) is not None
+            and (ogl_exp := resolved_parameters[field.alias].original_expression) is not None
+        ):
+            # A boolean expression was evaluated for this field and failed
+            do_field_boolean_expression_evaluated_check(soft_checker, der_rating, field, ogl_exp)
         elif isinstance(raw_value, bool):
-            field = params.__pydantic_fields__[k]
             do_field_exists_check(soft_checker, der_rating, field, raw_value)
 
     return soft_checker.finalize()
@@ -925,7 +992,8 @@ async def run_check(check: Check, active_test_procedure: ActiveTestProcedure, se
         UnknownCheckError: Raised if this function has no implementation for the provided `check.type`.
         FailedCheckError: Raised if this function encounters an exception while running the check.
     """
-    resolved_parameters = await resolve_variable_expressions_from_parameters(session, check.parameters)
+    resolved_with_metadata_parameters = await resolve_variable_expressions_from_parameters(session, check.parameters)
+    resolved_parameters = {k: v.value for k, v in resolved_with_metadata_parameters.items()}
     check_result: CheckResult | None = None
     pen: int = active_test_procedure.pen
     try:
@@ -938,10 +1006,10 @@ async def run_check(check: Check, active_test_procedure: ActiveTestProcedure, se
                 check_result = await check_end_device_contents(active_test_procedure, session, resolved_parameters)
 
             case "der-settings-contents":
-                check_result = await check_der_settings_contents(session, resolved_parameters)
+                check_result = await check_der_settings_contents(session, resolved_with_metadata_parameters)
 
             case "der-capability-contents":
-                check_result = await check_der_capability_contents(session, resolved_parameters)
+                check_result = await check_der_capability_contents(session, resolved_with_metadata_parameters)
 
             case "der-status-contents":
                 check_result = await check_der_status_contents(session, resolved_parameters)

--- a/src/cactus_runner/app/evaluator.py
+++ b/src/cactus_runner/app/evaluator.py
@@ -19,6 +19,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 @dataclasses.dataclass
 class ResolvedParam:
     """A dataclass for holding all metadata related to a resolved parameter"""
+
     value: Any
     original_expression: BaseExpression | None = None
 
@@ -113,10 +114,7 @@ async def resolve_variable_expressions_from_parameters(
     output_parameters: dict[str, ResolvedParam] = {}
     for k, v in parameters.items():
         if is_resolvable_variable(v):
-            output_parameters[k] = ResolvedParam(
-                value=await resolve_variable(session, v),
-                original_expression=v
-            )
+            output_parameters[k] = ResolvedParam(value=await resolve_variable(session, v), original_expression=v)
         else:
             output_parameters[k] = ResolvedParam(value=v)
 

--- a/src/cactus_runner/app/evaluator.py
+++ b/src/cactus_runner/app/evaluator.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+import dataclasses
+
 from cactus_runner.app import resolvers
 
 from cactus_test_definitions.variable_expressions import (
@@ -8,9 +10,17 @@ from cactus_test_definitions.variable_expressions import (
     NamedVariable,
     NamedVariableType,
     OperationType,
+    BaseExpression,
 )
 from cactus_test_definitions.errors import UnresolvableVariableError
 from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@dataclasses.dataclass
+class ResolvedParam:
+    """A dataclass for holding all metadata related to a resolved parameter"""
+    value: Any
+    original_expression: BaseExpression | None = None
 
 
 def is_resolvable_variable(v: Any) -> bool:
@@ -93,18 +103,21 @@ async def resolve_variable(session: AsyncSession, v: NamedVariable | Expression 
 
 async def resolve_variable_expressions_from_parameters(
     session: AsyncSession, parameters: dict[str, Any]
-) -> dict[str, Any]:
+) -> dict[str, ResolvedParam]:
     """Iterates parameters, finding any resolvable variables and then calling resolve_variable on it.
 
     parameters will NOT be mutated, a cloned set of "resolved" parameters (shallow copy) will be returned.
 
     raises UnresolvableVariableError on failure"""
 
-    output_parameters: dict[str, Any] = {}
+    output_parameters: dict[str, ResolvedParam] = {}
     for k, v in parameters.items():
         if is_resolvable_variable(v):
-            output_parameters[k] = await resolve_variable(session, v)
+            output_parameters[k] = ResolvedParam(
+                value=await resolve_variable(session, v),
+                original_expression=v
+            )
         else:
-            output_parameters[k] = v
+            output_parameters[k] = ResolvedParam(value=v)
 
     return output_parameters

--- a/tests/unit/app/test_check.py
+++ b/tests/unit/app/test_check.py
@@ -1,6 +1,7 @@
 import unittest.mock as mock
+import re
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Literal
 
 import pytest
 from assertical.fake.generator import generate_class_instance
@@ -13,6 +14,7 @@ from cactus_test_definitions.client import (
     Step,
     TestProcedure,
 )
+from cactus_test_definitions import variable_expressions
 from envoy.server.model.aggregator import Aggregator
 from envoy.server.model.archive.doe import ArchiveDynamicOperatingEnvelope
 from envoy.server.model.doe import DynamicOperatingEnvelope, SiteControlGroup
@@ -69,6 +71,7 @@ from cactus_runner.app.check import (
 )
 from cactus_runner.app.envoy_common import ReadingLocation
 from cactus_runner.models import ActiveTestProcedure, Listener
+from cactus_runner.app import evaluator
 
 # This is a list of every check type paired with the handler function. This must be kept in sync with
 # the checks defined in cactus test definitions (via CHECK_PARAMETER_SCHEMA). This sync will be enforced
@@ -393,31 +396,54 @@ async def test_check_end_device_lfdi(
     assert_check_result(result, expected)
 
 
+DERKey = Literal["site_der_setting", "site_der_rating"]
+
+
 def der_bool_param_scenario(
-    der_key: str,
+    der_key: DERKey,
     der_type: type,
     param: str,
     param_value: bool,
     db_property: str,
     db_property_value: Any,
     expected: bool,
-) -> tuple[list, dict[str, bool], bool]:
-    """Convenience for generating scenarios for testing the der settings/capability boolean param checks"""
-    der_props = {der_key: generate_class_instance(der_type, **{db_property: db_property_value})}
-    # raise Exception(f"der_key={der_key} der={der}")
-    return pytest.param(
-        [
-            generate_class_instance(
-                Site,
-                seed=101,
-                aggregator_id=1,
-                site_ders=[generate_class_instance(SiteDER, **der_props)],
-            )
-        ],
-        {param: param_value},
-        expected,
-        id=f"boolcheck-{param}-{param_value}-{db_property}-{db_property_value}-expecting-{expected}",
-    )
+) -> Any:
+    """Convenience for generating scenarios for testing the der settings/capability boolean param checks.
+
+    Returns: pytest ParameterSet to be used in pytest.mark.parametrize
+    """
+    der_props: dict[DERKey, SiteDERSetting | SiteDERRating] = {
+        der_key: generate_class_instance(der_type, **{db_property: db_property_value})
+    }
+
+    if der_key == "site_der_rating":
+        return pytest.param(
+            [
+                generate_class_instance(
+                    Site,
+                    seed=101,
+                    aggregator_id=1,
+                    site_ders=[generate_class_instance(SiteDER, site_der_rating=der_props[der_key])],
+                )
+            ],
+            {param: evaluator.ResolvedParam(param_value)},
+            expected,
+            id=f"boolcheck-{param}-{param_value}-{db_property}-{db_property_value}-expecting-{expected}",
+        )
+    if der_key == "site_der_setting":
+        return pytest.param(
+            [
+                generate_class_instance(
+                    Site,
+                    seed=101,
+                    aggregator_id=1,
+                    site_ders=[generate_class_instance(SiteDER, site_der_setting=der_props[der_key])],
+                )
+            ],
+            {param: evaluator.ResolvedParam(param_value)},
+            expected,
+            id=f"boolcheck-{param}-{param_value}-{db_property}-{db_property_value}-expecting-{expected}",
+        )
 
 
 DERSETTING_BOOL_PARAM_SCENARIOS = [
@@ -477,7 +503,7 @@ DERSETTING_BOOL_PARAM_SCENARIOS = [
                     ],
                 )
             ],
-            {"setGradW": 12345},
+            {"setGradW": evaluator.ResolvedParam(12345, variable_expressions.Constant(12345))},
             True,
         ),
         (
@@ -493,7 +519,7 @@ DERSETTING_BOOL_PARAM_SCENARIOS = [
                     ],
                 )
             ],
-            {"setGradW": 1234},
+            {"setGradW": evaluator.ResolvedParam(1234)},
             False,
         ),  # setGradW doesn't match value
         (
@@ -547,7 +573,7 @@ DERSETTING_BOOL_PARAM_SCENARIOS = [
                     ],
                 )
             ],
-            {"doeModesEnabled_set": "03"},
+            {"doeModesEnabled_set": evaluator.ResolvedParam("03")},
             True,
         ),
         (
@@ -564,7 +590,7 @@ DERSETTING_BOOL_PARAM_SCENARIOS = [
                     ],
                 )
             ],
-            {"doeModesEnabled_set": "03"},
+            {"doeModesEnabled_set": evaluator.ResolvedParam("03")},
             False,
         ),  # Bit flag 1 not set on actual value
         (
@@ -581,7 +607,7 @@ DERSETTING_BOOL_PARAM_SCENARIOS = [
                     ],
                 )
             ],
-            {"modesEnabled_set": "03"},
+            {"modesEnabled_set": evaluator.ResolvedParam("03")},
             True,
         ),
         (
@@ -598,7 +624,7 @@ DERSETTING_BOOL_PARAM_SCENARIOS = [
                     ],
                 )
             ],
-            {"modesEnabled_set": "03"},
+            {"modesEnabled_set": evaluator.ResolvedParam("03")},
             False,
         ),  # Bit flag 1 not set on actual value
         (
@@ -615,7 +641,7 @@ DERSETTING_BOOL_PARAM_SCENARIOS = [
                     ],
                 )
             ],
-            {"doeModesEnabled_unset": "03"},
+            {"doeModesEnabled_unset": evaluator.ResolvedParam("03")},
             True,
         ),
         (
@@ -632,7 +658,7 @@ DERSETTING_BOOL_PARAM_SCENARIOS = [
                     ],
                 )
             ],
-            {"doeModesEnabled_unset": "03"},
+            {"doeModesEnabled_unset": evaluator.ResolvedParam("03")},
             False,
         ),  # Bit flag 1 set on actual value
         (
@@ -649,7 +675,7 @@ DERSETTING_BOOL_PARAM_SCENARIOS = [
                     ],
                 )
             ],
-            {"modesEnabled_unset": "03"},
+            {"modesEnabled_unset": evaluator.ResolvedParam("03")},
             True,
         ),
         (
@@ -666,7 +692,7 @@ DERSETTING_BOOL_PARAM_SCENARIOS = [
                     ],
                 )
             ],
-            {"modesEnabled_unset": "03"},
+            {"modesEnabled_unset": evaluator.ResolvedParam("03")},
             False,
         ),  # Bit flag 1 set on actual value
         *DERSETTING_BOOL_PARAM_SCENARIOS,
@@ -780,7 +806,7 @@ DERRATING_BOOL_PARAM_SCENARIOS = [
                     ],
                 )
             ],
-            {"doeModesSupported_set": "03"},
+            {"doeModesSupported_set": evaluator.ResolvedParam("03")},
             True,
         ),
         (
@@ -797,7 +823,7 @@ DERRATING_BOOL_PARAM_SCENARIOS = [
                     ],
                 )
             ],
-            {"doeModesSupported_set": "03"},
+            {"doeModesSupported_set": evaluator.ResolvedParam("03")},
             False,
         ),  # Bit flag 1 not set on actual value
         (
@@ -814,7 +840,7 @@ DERRATING_BOOL_PARAM_SCENARIOS = [
                     ],
                 )
             ],
-            {"modesSupported_set": "03"},
+            {"modesSupported_set": evaluator.ResolvedParam("03")},
             True,
         ),
         (
@@ -831,7 +857,7 @@ DERRATING_BOOL_PARAM_SCENARIOS = [
                     ],
                 )
             ],
-            {"modesSupported_set": "03"},
+            {"modesSupported_set": evaluator.ResolvedParam("03")},
             False,
         ),  # Bit flag 1 not set on actual value
         (
@@ -848,7 +874,7 @@ DERRATING_BOOL_PARAM_SCENARIOS = [
                     ],
                 )
             ],
-            {"doeModesSupported_unset": "03"},
+            {"doeModesSupported_unset": evaluator.ResolvedParam("03")},
             True,
         ),
         (
@@ -865,7 +891,7 @@ DERRATING_BOOL_PARAM_SCENARIOS = [
                     ],
                 )
             ],
-            {"doeModesSupported_unset": "03"},
+            {"doeModesSupported_unset": evaluator.ResolvedParam("03")},
             False,
         ),  # Bit flag 1 set on actual value
         (
@@ -882,7 +908,7 @@ DERRATING_BOOL_PARAM_SCENARIOS = [
                     ],
                 )
             ],
-            {"modesSupported_unset": "03"},
+            {"modesSupported_unset": evaluator.ResolvedParam("03")},
             True,
         ),
         (
@@ -899,7 +925,7 @@ DERRATING_BOOL_PARAM_SCENARIOS = [
                     ],
                 )
             ],
-            {"modesSupported_unset": "03"},
+            {"modesSupported_unset": evaluator.ResolvedParam("03")},
             False,
         ),  # Bit flag 1 set on actual value
         *DERRATING_BOOL_PARAM_SCENARIOS,
@@ -2362,3 +2388,394 @@ def test_timestamp_on_minute_boundary(timestamp_str: str, expected: bool):
 )
 def test_merge_check_results(checkresults: list[CheckResult], expected: CheckResult):
     assert merge_checks(checkresults) == expected
+
+
+@pytest.mark.parametrize(
+    "existing_sites, resolved_params, expected, msg_regex",
+    [
+        ([], {}, False, r"[Nn]o [Ee]nd[Dd]evice is currently registered"),
+        (
+            [
+                generate_class_instance(
+                    Site,
+                    seed=101,
+                    aggregator_id=1,
+                    site_ders=[
+                        generate_class_instance(
+                            SiteDER, site_der_setting=generate_class_instance(SiteDERSetting, grad_w=12345)
+                        )
+                    ],
+                )
+            ],
+            {"setGradW": evaluator.ResolvedParam(1234)},
+            False,
+            r"setGradW [0-9]+ doesn't match (expected)?[: ]+[0-9]+",
+        ),  # setGradW doesn't match value
+        (
+            [
+                generate_class_instance(
+                    Site,
+                    seed=101,
+                    aggregator_id=1,
+                    site_ders=[
+                        generate_class_instance(SiteDER, site_der_rating=generate_class_instance(SiteDERRating))
+                    ],
+                )
+            ],
+            {},
+            False,
+            r"No DERSetting found for [Ee]nd[Dd]evice [0-9]+",
+        ),  # Is setting DERCapability - not DERSetting
+        (
+            [
+                generate_class_instance(
+                    Site,
+                    seed=101,
+                    aggregator_id=1,
+                    site_ders=[generate_class_instance(SiteDER)],
+                )
+            ],
+            {},
+            False,
+            r"No DERSetting found for [Ee]nd[Dd]evice [0-9]+",
+        ),
+        (
+            [
+                generate_class_instance(
+                    Site,
+                    seed=101,
+                    aggregator_id=1,
+                )
+            ],
+            {},
+            False,
+            r"No DERSetting found for [Ee]nd[Dd]evice [0-9]+",
+        ),
+        (
+            [
+                generate_class_instance(
+                    Site,
+                    seed=101,
+                    aggregator_id=1,
+                    site_ders=[
+                        generate_class_instance(
+                            SiteDER,
+                            site_der_setting=generate_class_instance(SiteDERSetting, doe_modes_enabled=int("fe", 16)),
+                        )
+                    ],
+                )
+            ],
+            {"doeModesEnabled_set": evaluator.ResolvedParam("03")},
+            False,
+            r"doeModesEnabled_set.* minimum flag .* check hi.* failed",
+        ),  # Bit flag 1 not set on actual value
+        (
+            [
+                generate_class_instance(
+                    Site,
+                    seed=101,
+                    aggregator_id=1,
+                    site_ders=[
+                        generate_class_instance(
+                            SiteDER,
+                            site_der_setting=generate_class_instance(SiteDERSetting, modes_enabled=int("fe", 16)),
+                        )
+                    ],
+                )
+            ],
+            {"modesEnabled_set": evaluator.ResolvedParam("03")},
+            False,
+            r"modesEnabled_set.* minimum flag .* check hi.* failed",
+        ),  # Bit flag 1 not set on actual value
+        (
+            [
+                generate_class_instance(
+                    Site,
+                    seed=101,
+                    aggregator_id=1,
+                    site_ders=[
+                        generate_class_instance(
+                            SiteDER,
+                            site_der_setting=generate_class_instance(SiteDERSetting, doe_modes_enabled=int("fd", 16)),
+                        )
+                    ],
+                )
+            ],
+            {"doeModesEnabled_unset": evaluator.ResolvedParam("03")},
+            False,
+            r"doeModesEnabled_unset.* minimum flag .* check lo.* failed",
+        ),  # Bit flag 1 set on actual value
+        (
+            [
+                generate_class_instance(
+                    Site,
+                    seed=101,
+                    aggregator_id=1,
+                    site_ders=[
+                        generate_class_instance(
+                            SiteDER,
+                            site_der_setting=generate_class_instance(SiteDERSetting, modes_enabled=int("fd", 16)),
+                        )
+                    ],
+                )
+            ],
+            {"modesEnabled_unset": evaluator.ResolvedParam("03")},
+            False,
+            r"modesEnabled_unset.* minimum flag .* check lo.* failed",
+        ),  # Bit flag 1 set on actual value
+        (
+            [
+                generate_class_instance(
+                    Site,
+                    seed=101,
+                    aggregator_id=1,
+                    site_ders=[
+                        generate_class_instance(
+                            SiteDER,
+                            site_der_setting=generate_class_instance(SiteDERSetting, max_va_value=12345),
+                        )
+                    ],
+                )
+            ],
+            {
+                "setMaxVA": evaluator.ResolvedParam(
+                    False,
+                    variable_expressions.Expression(
+                        variable_expressions.OperationType.EQ,
+                        variable_expressions.NamedVariable(
+                            variable_expressions.NamedVariableType.DERSETTING_SET_MAX_VA
+                        ),
+                        variable_expressions.Constant(54321),
+                    ),
+                )
+            },
+            False,
+            r"setMaxVA (must|MUST) satisfy (expression)?.*setMaxVA ?== ?54321.*currently set as[: ]{1} ?12345",
+        ),  # Expression boolean not met
+        (
+            [
+                generate_class_instance(
+                    Site,
+                    seed=101,
+                    aggregator_id=1,
+                    site_ders=[
+                        generate_class_instance(
+                            SiteDER,
+                            site_der_setting=generate_class_instance(SiteDERSetting, max_va_value=12345),
+                        )
+                    ],
+                )
+            ],
+            {
+                "setMaxVA": evaluator.ResolvedParam(
+                    False,
+                    None,
+                )
+            },
+            False,
+            r"setMaxVA (MUST|must).* unset.* currently.*:? 12345",
+        ),  # Set boolean not met
+    ],
+)
+@pytest.mark.anyio
+async def test_check_der_settings_contents_error_messages_meaningful(
+    pg_base_config, existing_sites: list[Site], resolved_params: dict[str, Any], expected: bool, msg_regex: str
+):
+    async with generate_async_session(pg_base_config) as session:
+        session.add_all(existing_sites)
+        await session.commit()
+
+    async with generate_async_session(pg_base_config) as session:
+        result = await check_der_settings_contents(session, resolved_params)
+        assert_check_result(result, expected)
+        assert result.description is not None
+        assert (
+            re.search(msg_regex, result.description) is not None
+        ), f"'{msg_regex}' not found in '{result.description}'"
+
+
+@pytest.mark.parametrize(
+    "existing_sites, resolved_params, expected, msg_regex",
+    [
+        ([], {}, False, r"[Nn]o [Ee]nd ?[Dd]evice is currently registered"),
+        (
+            [
+                generate_class_instance(
+                    Site,
+                    seed=101,
+                    aggregator_id=1,
+                    site_ders=[
+                        generate_class_instance(SiteDER, site_der_setting=generate_class_instance(SiteDERSetting))
+                    ],
+                )
+            ],
+            {},
+            False,
+            r"[Nn]o DERCapability found for [Ee]nd ?[Dd]evice [0-9]+",
+        ),  # Is setting DERSetting not DERCapability
+        (
+            [
+                generate_class_instance(
+                    Site,
+                    seed=101,
+                    aggregator_id=1,
+                    site_ders=[generate_class_instance(SiteDER)],
+                )
+            ],
+            {},
+            False,
+            r"[Nn]o DERCapability found for [Ee]nd ?[Dd]evice [0-9]+",
+        ),
+        (
+            [
+                generate_class_instance(
+                    Site,
+                    seed=101,
+                    aggregator_id=1,
+                )
+            ],
+            {},
+            False,
+            r"[Nn]o DERCapability found for [Ee]nd ?[Dd]evice [0-9]+",
+        ),
+        (
+            [
+                generate_class_instance(
+                    Site,
+                    seed=101,
+                    aggregator_id=1,
+                    site_ders=[
+                        generate_class_instance(
+                            SiteDER,
+                            site_der_rating=generate_class_instance(SiteDERRating, doe_modes_supported=int("fe", 16)),
+                        )
+                    ],
+                )
+            ],
+            {"doeModesSupported_set": evaluator.ResolvedParam("03")},
+            False,
+            r"doeModesSupported_set.* minimum flag .* check hi.* failed",
+        ),  # Bit flag 1 not set on actual value
+        (
+            [
+                generate_class_instance(
+                    Site,
+                    seed=101,
+                    aggregator_id=1,
+                    site_ders=[
+                        generate_class_instance(
+                            SiteDER,
+                            site_der_rating=generate_class_instance(SiteDERRating, modes_supported=int("fe", 16)),
+                        )
+                    ],
+                )
+            ],
+            {"modesSupported_set": evaluator.ResolvedParam("03")},
+            False,
+            r"modesSupported_set.* minimum flag .* check hi.* failed",
+        ),  # Bit flag 1 not set on actual value
+        (
+            [
+                generate_class_instance(
+                    Site,
+                    seed=101,
+                    aggregator_id=1,
+                    site_ders=[
+                        generate_class_instance(
+                            SiteDER,
+                            site_der_rating=generate_class_instance(SiteDERRating, doe_modes_supported=int("fd", 16)),
+                        )
+                    ],
+                )
+            ],
+            {"doeModesSupported_unset": evaluator.ResolvedParam("03")},
+            False,
+            r"doeModesSupported_unset.* minimum flag .* check lo.* failed",
+        ),  # Bit flag 1 set on actual value
+        (
+            [
+                generate_class_instance(
+                    Site,
+                    seed=101,
+                    aggregator_id=1,
+                    site_ders=[
+                        generate_class_instance(
+                            SiteDER,
+                            site_der_rating=generate_class_instance(SiteDERRating, modes_supported=int("fd", 16)),
+                        )
+                    ],
+                )
+            ],
+            {"modesSupported_unset": evaluator.ResolvedParam("03")},
+            False,
+            r"modesSupported_unset.* minimum flag .* check lo.* failed",
+        ),  # Bit flag 1 set on actual value
+        (
+            [
+                generate_class_instance(
+                    Site,
+                    seed=101,
+                    aggregator_id=1,
+                    site_ders=[
+                        generate_class_instance(
+                            SiteDER,
+                            site_der_rating=generate_class_instance(SiteDERRating, max_va_value=12345),
+                        )
+                    ],
+                )
+            ],
+            {
+                "rtgMaxVA": evaluator.ResolvedParam(
+                    False,
+                    variable_expressions.Expression(
+                        variable_expressions.OperationType.EQ,
+                        variable_expressions.NamedVariable(
+                            variable_expressions.NamedVariableType.DERCAPABILITY_RTG_MAX_VA
+                        ),
+                        variable_expressions.Constant(54321),
+                    ),
+                )
+            },
+            False,
+            r"rtgMaxVA (must|MUST) satisfy (expression)?.*rtgMaxVA ?== ?54321.*currently set as[: ]{1} ?12345",
+        ),  # Expression boolean not met
+        (
+            [
+                generate_class_instance(
+                    Site,
+                    seed=101,
+                    aggregator_id=1,
+                    site_ders=[
+                        generate_class_instance(
+                            SiteDER,
+                            site_der_rating=generate_class_instance(SiteDERRating, max_va_value=12345),
+                        )
+                    ],
+                )
+            ],
+            {
+                "rtgMaxVA": evaluator.ResolvedParam(
+                    False,
+                    None,
+                )
+            },
+            False,
+            r"rtgMaxVA (MUST|must).* unset.* currently.*:? 12345",
+        ),  # Set boolean not met
+    ],
+)
+@pytest.mark.anyio
+async def test_check_der_capability_contents_error_messages_meaningful(
+    pg_base_config, existing_sites: list[Site], resolved_params: dict[str, Any], expected: bool, msg_regex: str
+):
+    async with generate_async_session(pg_base_config) as session:
+        session.add_all(existing_sites)
+        await session.commit()
+
+    async with generate_async_session(pg_base_config) as session:
+        result = await check_der_capability_contents(session, resolved_params)
+        assert_check_result(result, expected)
+        assert result.description is not None
+        assert (
+            re.search(msg_regex, result.description) is not None
+        ), f"'{msg_regex}' not found in '{result.description}'"

--- a/tests/unit/app/test_evaluator.py
+++ b/tests/unit/app/test_evaluator.py
@@ -169,9 +169,9 @@ async def test_resolve_variable_expressions_from_parameters(
     for k, input_val in input_dict.items():
         assert k in actual_dict
         if k in variable_keys:
-            assert actual_dict[k] is MOCK_RESOLVED_VALUE, "Resolved variables should be... resolved"
+            assert actual_dict[k].value is MOCK_RESOLVED_VALUE, "Resolved variables should be... resolved"
         else:
-            assert actual_dict[k] is input_val, "All other variables/params should be shallow copied across"
+            assert actual_dict[k].value is input_val, "All other variables/params should be shallow copied across"
 
     assert_mock_session(mock_session)
     assert mock_resolve_variable.call_count == len(variable_keys)

--- a/tests/unit/app/test_event.py
+++ b/tests/unit/app/test_event.py
@@ -10,6 +10,7 @@ from assertical.fake.sqlalchemy import assert_mock_session, create_mock_session
 from cactus_test_definitions.client import Event
 
 from cactus_runner.app import event
+from cactus_runner.app import evaluator
 from cactus_runner.models import ActiveTestProcedure, Listener, RunnerState
 
 
@@ -104,7 +105,7 @@ def test_generate_client_request_trigger(request_method: str, request_path: str,
             event.EventTrigger(event.EventTriggerType.TIME, datetime(2022, 11, 10, tzinfo=timezone.utc), False, None),
             Listener(
                 step="step",
-                event=Event(type="GET-request-received", parameters={"endpoint": "/dcap"}),
+                event=Event(type="GET-request-received", parameters={"endpoint": evaluator.ResolvedParam("/dcap")}),
                 actions=[],
                 enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
             ),
@@ -124,7 +125,7 @@ def test_generate_client_request_trigger(request_method: str, request_path: str,
             event.EventTrigger(event.EventTriggerType.TIME, datetime(2022, 11, 10, tzinfo=timezone.utc), False, None),
             Listener(
                 step="step",
-                event=Event(type="wait", parameters={"duration_seconds": 300}),
+                event=Event(type="wait", parameters={"duration_seconds": evaluator.ResolvedParam(300)}),
                 actions=[],
                 enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
             ),
@@ -136,7 +137,7 @@ def test_generate_client_request_trigger(request_method: str, request_path: str,
             ),
             Listener(
                 step="step",
-                event=Event(type="wait", parameters={"duration_seconds": 300}),
+                event=Event(type="wait", parameters={"duration_seconds": evaluator.ResolvedParam(300)}),
                 actions=[],
                 enabled_time=datetime(2024, 11, 10, 5, 24, 0, tzinfo=timezone.utc),
             ),
@@ -148,7 +149,7 @@ def test_generate_client_request_trigger(request_method: str, request_path: str,
             ),
             Listener(
                 step="step",
-                event=Event(type="wait", parameters={"duration_seconds": 300}),
+                event=Event(type="wait", parameters={"duration_seconds": evaluator.ResolvedParam(300)}),
                 actions=[],
                 enabled_time=None,
             ),
@@ -160,7 +161,7 @@ def test_generate_client_request_trigger(request_method: str, request_path: str,
             ),
             Listener(
                 step="step",
-                event=Event(type="wait", parameters={"duration_seconds": 300}),
+                event=Event(type="wait", parameters={"duration_seconds": evaluator.ResolvedParam(300)}),
                 actions=[],
                 enabled_time=datetime(2024, 11, 10, 5, 26, 0, tzinfo=timezone.utc),
             ),
@@ -175,7 +176,7 @@ def test_generate_client_request_trigger(request_method: str, request_path: str,
             ),
             Listener(
                 step="step",
-                event=Event(type="GET-request-received", parameters={"endpoint": "/foo/bar"}),
+                event=Event(type="GET-request-received", parameters={"endpoint": evaluator.ResolvedParam("/foo/bar")}),
                 actions=[],
                 enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
             ),
@@ -190,7 +191,7 @@ def test_generate_client_request_trigger(request_method: str, request_path: str,
             ),
             Listener(
                 step="step",
-                event=Event(type="POST-request-received", parameters={"endpoint": "/foo/bar"}),
+                event=Event(type="POST-request-received", parameters={"endpoint": evaluator.ResolvedParam("/foo/bar")}),
                 actions=[],
                 enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
             ),
@@ -205,7 +206,7 @@ def test_generate_client_request_trigger(request_method: str, request_path: str,
             ),
             Listener(
                 step="step",
-                event=Event(type="PUT-request-received", parameters={"endpoint": "/foo/bar"}),
+                event=Event(type="PUT-request-received", parameters={"endpoint": evaluator.ResolvedParam("/foo/bar")}),
                 actions=[],
                 enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
             ),
@@ -221,7 +222,11 @@ def test_generate_client_request_trigger(request_method: str, request_path: str,
             Listener(
                 step="step",
                 event=Event(
-                    type="GET-request-received", parameters={"endpoint": "/foo/bar", "serve_request_first": False}
+                    type="GET-request-received",
+                    parameters={
+                        "endpoint": evaluator.ResolvedParam("/foo/bar"),
+                        "serve_request_first": evaluator.ResolvedParam(False),
+                    },
                 ),
                 actions=[],
                 enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
@@ -238,7 +243,11 @@ def test_generate_client_request_trigger(request_method: str, request_path: str,
             Listener(
                 step="step",
                 event=Event(
-                    type="GET-request-received", parameters={"endpoint": "/foo/bar", "serve_request_first": True}
+                    type="GET-request-received",
+                    parameters={
+                        "endpoint": evaluator.ResolvedParam("/foo/bar"),
+                        "serve_request_first": evaluator.ResolvedParam(True),
+                    },
                 ),
                 actions=[],
                 enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
@@ -254,7 +263,9 @@ def test_generate_client_request_trigger(request_method: str, request_path: str,
             ),
             Listener(
                 step="step",
-                event=Event(type="GET-request-received", parameters={"endpoint": "/my/endppoint/1"}),
+                event=Event(
+                    type="GET-request-received", parameters={"endpoint": evaluator.ResolvedParam("/my/endppoint/1")}
+                ),
                 actions=[],
                 enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
             ),
@@ -269,7 +280,7 @@ def test_generate_client_request_trigger(request_method: str, request_path: str,
             ),
             Listener(
                 step="step",
-                event=Event(type="GET-request-received", parameters={"endpoint": "/foo/bar"}),
+                event=Event(type="GET-request-received", parameters={"endpoint": evaluator.ResolvedParam("/foo/bar")}),
                 actions=[],
                 enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
             ),
@@ -284,7 +295,7 @@ def test_generate_client_request_trigger(request_method: str, request_path: str,
             ),
             Listener(
                 step="step",
-                event=Event(type="GET-request-received", parameters={"endpoint": "/foo/bar"}),
+                event=Event(type="GET-request-received", parameters={"endpoint": evaluator.ResolvedParam("/foo/bar")}),
                 actions=[],
                 enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
             ),
@@ -299,7 +310,7 @@ def test_generate_client_request_trigger(request_method: str, request_path: str,
             ),
             Listener(
                 step="step",
-                event=Event(type="GET-request-received", parameters={"endpoint": "/foo"}),
+                event=Event(type="GET-request-received", parameters={"endpoint": evaluator.ResolvedParam("/foo")}),
                 actions=[],
                 enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
             ),
@@ -314,7 +325,7 @@ def test_generate_client_request_trigger(request_method: str, request_path: str,
             ),
             Listener(
                 step="step",
-                event=Event(type="GET-request-received", parameters={"endpoint": "/foo/bar"}),
+                event=Event(type="GET-request-received", parameters={"endpoint": evaluator.ResolvedParam("/foo/bar")}),
                 actions=[],
                 enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
             ),
@@ -329,7 +340,7 @@ def test_generate_client_request_trigger(request_method: str, request_path: str,
             ),
             Listener(
                 step="step",
-                event=Event(type="GET-request-received", parameters={"endpoint": "/foo/bar"}),
+                event=Event(type="GET-request-received", parameters={"endpoint": evaluator.ResolvedParam("/foo/bar")}),
                 actions=[],
                 enabled_time=None,
             ),
@@ -344,7 +355,9 @@ def test_generate_client_request_trigger(request_method: str, request_path: str,
             ),
             Listener(
                 step="step",
-                event=Event(type="GET-request-received", parameters={"endpoint": "/foo/*/bar/*"}),
+                event=Event(
+                    type="GET-request-received", parameters={"endpoint": evaluator.ResolvedParam("/foo/*/bar/*")}
+                ),
                 actions=[],
                 enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
             ),
@@ -352,7 +365,7 @@ def test_generate_client_request_trigger(request_method: str, request_path: str,
         ),
     ],
 )
-@patch("cactus_runner.app.event.resolve_variable_expressions_from_parameters")
+@patch("cactus_runner.app.event.evaluator.resolve_variable_expressions_from_parameters")
 @pytest.mark.anyio
 async def test_is_listener_triggerable(
     mock_resolve_variable_expressions_from_parameters: MagicMock,


### PR DESCRIPTION
To enable pass through of evaluation results for scrutiny in further checks. 
This enables a fix to resolving the poor reporting of failed boolean expressions that have been evaluated, discovered during Fronius's recent testing.
This relies upon https://github.com/bsgip/cactus-test-definitions/pull/34 being merged prior. 
Synergy reference - Closes AB#205197 