### PR TITLE
Bugfix for reporting bug

### DIFF
--- a/src/cactus_runner/app/envoy_common.py
+++ b/src/cactus_runner/app/envoy_common.py
@@ -145,7 +145,6 @@ async def get_reading_counts_grouped_by_reading_type(session: AsyncSession) -> d
 
     count_by_site_reading_type_id: dict[int, int] = {}
     for site_reading_type, count in count_resp.all():
-        print(f"{site_reading_type=} {count=}")
         count_by_site_reading_type_id[site_reading_type] = count
 
     site_reading_type_ids = list(count_by_site_reading_type_id.keys())
@@ -156,6 +155,8 @@ async def get_reading_counts_grouped_by_reading_type(session: AsyncSession) -> d
 
     count_by_site_reading_type: dict[SiteReadingType, int] = {}
     for reading_type in reading_types_resp.scalars().all():
+        # Convert uom from int to UomType
+        reading_type.uom = UomType(reading_type.uom)
         count_by_site_reading_type[reading_type] = count_by_site_reading_type_id[reading_type.site_reading_type_id]
 
     return count_by_site_reading_type

--- a/src/cactus_runner/app/readings.py
+++ b/src/cactus_runner/app/readings.py
@@ -99,6 +99,9 @@ async def get_readings(
             qualifier=reading_specifier.qualifier,
         )
         for reading_type in reading_types:
+            # Convert uom from int to UomType
+            reading_type.uom = UomType(reading_type.uom)
+
             reading_data = await get_site_readings(session=session, site_reading_type=reading_type)
 
             if reading_data:

--- a/src/cactus_runner/app/reporting.py
+++ b/src/cactus_runner/app/reporting.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta, timezone
 from functools import partial
 from http import HTTPStatus
 from typing import Sequence
-from reportlab.lib import colors
+
 import pandas as pd
 import PIL.Image as PilImage
 import plotly.express as px  # type: ignore
@@ -21,7 +21,15 @@ from envoy.server.model import (
     SiteDERStatus,
 )
 from envoy.server.model.site_reading import SiteReadingType
-from envoy_schema.server.schema.sep2.types import DataQualifierType, DeviceCategory, PhaseCode, UomType, KindType
+from envoy_schema.server.schema.sep2.types import (
+    DataQualifierType,
+    DeviceCategory,
+    KindType,
+    PhaseCode,
+    RoleFlagsType,
+    UomType,
+)
+from reportlab.lib import colors
 from reportlab.lib.colors import Color, HexColor
 from reportlab.lib.pagesizes import A4
 from reportlab.lib.styles import (
@@ -56,7 +64,6 @@ from cactus_runner.models import (
     RequestEntry,
     RunnerState,
 )
-from envoy_schema.server.schema.sep2.types import RoleFlagsType
 
 logger = logging.getLogger(__name__)
 
@@ -1161,7 +1168,7 @@ def generate_readings_timeline(
 
 
 def reading_quantity(srt: SiteReadingType) -> str:
-    quantity = UomType(srt.uom).name
+    quantity = srt.uom.name
     quantity = quantity.replace("_", " ").title()
     return quantity
 

--- a/tests/unit/app/test_envoy_common.py
+++ b/tests/unit/app/test_envoy_common.py
@@ -2,16 +2,16 @@ from datetime import datetime
 from decimal import Decimal
 
 import pytest
+import sqlalchemy
 from assertical.asserts.type import assert_list_type
 from assertical.fake.generator import generate_class_instance
 from assertical.fixtures.postgres import generate_async_session
 from envoy.server.model.archive.doe import (
     ArchiveDynamicOperatingEnvelope,
 )
-from envoy.server.model.site import Site, SiteDERSetting, SiteDER, DefaultSiteControl
-
 from envoy.server.model.archive.site import ArchiveDefaultSiteControl
 from envoy.server.model.doe import DynamicOperatingEnvelope, SiteControlGroup
+from envoy.server.model.site import DefaultSiteControl, Site, SiteDER, SiteDERSetting
 from envoy.server.model.site_reading import SiteReading, SiteReadingType
 from envoy_schema.server.schema.sep2.types import (
     DataQualifierType,
@@ -19,7 +19,6 @@ from envoy_schema.server.schema.sep2.types import (
     RoleFlagsType,
     UomType,
 )
-import sqlalchemy
 
 from cactus_runner.app.envoy_common import (
     ReadingLocation,
@@ -432,6 +431,10 @@ async def test_get_reading_counts_grouped_by_reading_type(pg_base_config):
         assert count_by_reading_type[power_type] == num_power_readings
         assert count_by_reading_type[voltage_type] == num_voltage_readings
         assert count_by_reading_type[energy_type] == num_energy_readings
+
+        # Check reading uom is UomType (bugfix for reporting issue)
+        for reading_type in count_by_reading_type.keys():
+            assert isinstance(reading_type.uom, UomType)
 
 
 @pytest.mark.anyio

--- a/tests/unit/app/test_readings.py
+++ b/tests/unit/app/test_readings.py
@@ -144,6 +144,10 @@ async def test_get_readings(pg_base_config):
         [len(readings) for readings in readings_map.values()]
     )
 
+    # Check reading uom is UomType (bugfix for reporting issue)
+    for reading_type in readings_map.keys():
+        assert isinstance(reading_type.uom, UomType)
+
 
 def test_merge_readings():
     # Arrange


### PR DESCRIPTION
The reporting code expected the uom of SiteReadingType variables to be of type UomType (and not he integers returned by the db query).

The code which retrieves the readings and counts of different reading types convert uom's from ints to UomTypes. This allows the reporting code to uses the uoms as expected (e.g. access their `.name` property).