### PR TITLE
Report regeneration fixes

### DIFF
--- a/src/cactus_runner/app/finalize.py
+++ b/src/cactus_runner/app/finalize.py
@@ -10,17 +10,18 @@ from pathlib import Path
 from typing import cast
 
 import pandas as pd
+from cactus_schema.runner.schema import RequestEntry
 from envoy.server.model.archive.site import ArchiveSiteDERSetting
 from envoy.server.model.site import SiteDERSetting
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from cactus_runner.app import check, reporting, timeline
-from cactus_runner.app.env import MAX_LOG_FILE_BYTES, MAX_REQUEST_PAIRS
 from cactus_runner.app.database import (
     DatabaseNotInitialisedError,
     get_postgres_dsn,
 )
+from cactus_runner.app.env import MAX_LOG_FILE_BYTES, MAX_REQUEST_PAIRS
 from cactus_runner.app.envoy_common import (
     get_reading_counts_grouped_by_reading_type,
     get_sites,
@@ -45,7 +46,6 @@ from cactus_runner.models import (
     RunnerState,
     Site,
 )
-from cactus_schema.runner.schema import RequestEntry
 
 # Cactus runner supports returning different versions of the reporting data
 # Define the currently preferred reporting data version
@@ -269,9 +269,10 @@ async def generate_json_reporting_data(
     try:
         # Repack readings into something serializable
         packed_readings = [
-            PackedReadings(reading_type=k, readings_as_json=readings[k].to_json(), reading_counts=v)
+            PackedReadings(
+                reading_type=k, readings_as_json=readings[k].to_json() if k in readings else None, reading_counts=v
+            )
             for k, v in reading_counts.items()
-            if k in readings
         ]
 
         reporting_data = ReportingData.v(version)(

--- a/src/cactus_runner/app/finalize.py
+++ b/src/cactus_runner/app/finalize.py
@@ -271,6 +271,7 @@ async def generate_json_reporting_data(
         packed_readings = [
             PackedReadings(reading_type=k, readings_as_json=readings[k].to_json(), reading_counts=v)
             for k, v in reading_counts.items()
+            if k in readings
         ]
 
         reporting_data = ReportingData.v(version)(

--- a/src/cactus_runner/app/readings.py
+++ b/src/cactus_runner/app/readings.py
@@ -130,7 +130,7 @@ def merge_readings(
         # Here we choose the first SiteReadingType in the group.
         primary_key: SiteReadingType = group[0]
         merged = pd.concat([readings[reading_type] for reading_type in group])
-        sorted = merged.sort_values(by=["time_period_start"])
+        sorted = merged.sort_values(by=["time_period_start"]).reset_index(drop=True)
         merged_readings[primary_key] = sorted
 
     return merged_readings

--- a/src/cactus_runner/models.py
+++ b/src/cactus_runner/models.py
@@ -264,7 +264,7 @@ class ReadingType(JSONWizard):
 @dataclass
 class PackedReadings(JSONWizard):
     reading_type: ReadingType
-    readings_as_json: str
+    readings_as_json: str | None
     reading_counts: int
 
 


### PR DESCRIPTION
finalize.py: Skip reading types in reading_counts that have no corresponding DataFrame in readings to prevent a KeyError when a DER reports non-mandatory reading types. e.g. Frequency is non mandatory so is present in reading_counts but not readings. Previously caused json_reporting_data to be None and broke report regeneration.

readings.py: Reset the DataFrame index after pd.concat in merge_readings to prevent duplicate index values when two equivalent reading types are merged, which previously caused a "DataFrame index must be unique for orient='columns'" with the same issue as above for regen.