### PR TITLE
Ruff

### DIFF
--- a/.github/workflows/linttest.yml
+++ b/.github/workflows/linttest.yml
@@ -1,4 +1,4 @@
-name: Linting and Testing
+name: CI
 on:
   push:
     branches: [main, csipaus.org/ns/v1.2, csipaus.org/ns/v1.3, csipaus.org/ns/v1.3-beta/storage]
@@ -7,16 +7,18 @@ on:
   workflow_dispatch:
 
 jobs:
-  ruff:
+  ruff_bandit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install ruff
-        run: pip install ruff
-      - name: Lint
+      - name: Install linters
+        run: pip install ruff bandit
+      - name: Lint (ruff)
         run: ruff check .
       - name: Format check
         run: ruff format --check .
+      - name: Security scan (bandit)
+        run: bandit -r src/
 
   mypy_py312:
     runs-on: ubuntu-latest

--- a/.github/workflows/linttest.yml
+++ b/.github/workflows/linttest.yml
@@ -7,61 +7,25 @@ on:
   workflow_dispatch:
 
 jobs:
-  bandit:
+  ruff:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3.1.0
-
-      - name: Security check - Bandit
-        uses: joshvote/bandit-report-artifacts@v0.0.6
-        with:
-          project_path: .
-          ignore_failure: false
-          config_file: pyproject.toml
-
-      - name: Security check report artifacts
-        uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: Security report
-          path: output/security_report.txt
-          overwrite: true
-
-  flake8_py312:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3.1.0
-
-      - name: Setup Python
-        uses: actions/setup-python@v4.2.0
-        with:
-          python-version: "3.12"
-
-      - name: Setup flake8 annotations
-        uses: rbialon/flake8-annotations@v1
-
-      - name: Lint with flake8
-        if: always()
-        run: |
-          pip install flake8
-          flake8 . --count --statistics
-
-  black_formatting:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: psf/black@stable
+      - uses: actions/checkout@v4
+      - name: Install ruff
+        run: pip install ruff
+      - name: Lint
+        run: ruff check .
+      - name: Format check
+        run: ruff format --check .
 
   mypy_py312:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4.2.0
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
@@ -76,15 +40,14 @@ jobs:
         run: |
           mypy .
 
-
   pytest_py312:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4.2.0
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
@@ -101,5 +64,3 @@ jobs:
         with:
           paths: .test_report.xml
         if: always()
-
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,12 +41,8 @@ Changelog = "https://github.com/bsgip/cactus-runner/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
 dev = [
-  "bandit",
-  "black",
-  "flake8",
-  "isort",
-  "mccabe",
   "mypy",
+  "ruff",
   "tox",
   "python-dotenv[cli]",
   "coverage",
@@ -94,15 +90,17 @@ env = [
 ]
 
 
-[tool.black]
+[tool.ruff]
 line-length = 120
 
-[tool.isort]
-profile = "black"
-src_paths = ["src", "tests"]
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "S", "C90", "B"]
 
-[tool.bandit]
-exclude_dirs = ["tests"]
+[tool.ruff.lint.mccabe]
+max-complexity = 15
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["S"]
 
 [tool.mypy]
 exclude = ["dist", "tests", "build"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ Changelog = "https://github.com/bsgip/cactus-runner/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
 dev = [
+  "bandit",
   "mypy",
   "ruff",
   "tox",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,13 +94,13 @@ env = [
 line-length = 120
 
 [tool.ruff.lint]
-select = ["E", "W", "F", "I", "S", "C90", "B"]
+select = ["E", "W", "F", "I", "S", "C90", "B", "UP", "ANN", "N"]
 
 [tool.ruff.lint.mccabe]
-max-complexity = 15
+max-complexity = 10
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**" = ["S"]
+"tests/**" = ["S", "ANN", "N"]
 
 [tool.mypy]
 exclude = ["dist", "tests", "build"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,17 +1,3 @@
-[flake8]
-max-line-length = 120
-max-complexity = 15
-exclude = 
-    = examples/
-    = build/
-
-[isort]
-force_grid_wrap = 0
-include_trailing_comma = True
-line_length = 120
-multi_line_output = 3
-use_parentheses = True
-
 [options]
 package_dir=
     = ./src

--- a/src/cactus_runner/app/action.py
+++ b/src/cactus_runner/app/action.py
@@ -174,7 +174,7 @@ async def action_set_default_der_control(
             load_limit_watts=(
                 UpdateDefaultValue(value=load_limit_watts) if load_limit_watts is not None else default_val
             ),
-            ramp_rate_percent_per_second=(  # noqa: E501
+            ramp_rate_percent_per_second=(
                 UpdateDefaultValue(value=set_grad_w) if set_grad_w is not None else default_val
             ),
         ),

--- a/src/cactus_runner/app/action.py
+++ b/src/cactus_runner/app/action.py
@@ -471,7 +471,7 @@ async def action_remove_function_set_assignment(
             await envoy_client.put_site_control_group(scg.site_control_group_id, request)
 
 
-async def apply_action(
+async def apply_action(  # noqa: C901
     action: Action, runner_state: RunnerState, session: AsyncSession, envoy_client: EnvoyAdminClient
 ):
     """Applies the action to the active test procedure.

--- a/src/cactus_runner/app/action.py
+++ b/src/cactus_runner/app/action.py
@@ -77,7 +77,7 @@ class FailedActionError(Exception):
 async def action_enable_steps(
     active_test_procedure: ActiveTestProcedure,
     resolved_parameters: dict[str, Any],
-):
+) -> None:
     """Applies the enable-steps action to the active test procedures.
 
     Each listener has a single test procedure step associated with it. A list of step names to enable is therefore
@@ -106,7 +106,7 @@ async def action_enable_steps(
 async def action_remove_steps(
     active_test_procedure: ActiveTestProcedure,
     resolved_parameters: dict[str, Any],
-):
+) -> None:
     """Applies the remove-steps action to the active test procedure.
 
     Each listener has a single test procedure step associated with it. A list of step names to disable is therefore
@@ -133,13 +133,13 @@ async def action_remove_steps(
         active_test_procedure.step_status[listener.step].completed_at = datetime.now(tz=UTC)
 
 
-async def action_finish_test(runner_state: RunnerState, session: AsyncSession):
+async def action_finish_test(runner_state: RunnerState, session: AsyncSession) -> None:
     await finish_active_test(runner_state, session)
 
 
 async def action_set_default_der_control(
     resolved_parameters: dict[str, Any], session: AsyncSession, envoy_client: EnvoyAdminClient
-):
+) -> None:
 
     derp_id: int | None = resolved_parameters.get("derp_id", None)
     import_limit_watts = resolved_parameters.get("opModImpLimW", None)
@@ -174,7 +174,9 @@ async def action_set_default_der_control(
             load_limit_watts=(
                 UpdateDefaultValue(value=load_limit_watts) if load_limit_watts is not None else default_val
             ),
-            ramp_rate_percent_per_second=UpdateDefaultValue(value=set_grad_w) if set_grad_w is not None else default_val,
+            ramp_rate_percent_per_second=(  # noqa: E501
+                UpdateDefaultValue(value=set_grad_w) if set_grad_w is not None else default_val
+            ),
         ),
     )
 
@@ -184,7 +186,7 @@ async def action_create_der_program(
     envoy_client: EnvoyAdminClient,
     active_test_procedure: ActiveTestProcedure,
     session: AsyncSession,
-):
+) -> None:
     primacy: int = int(resolved_parameters["primacy"])  # mandatory param
     fsa_id: int = int(resolved_parameters.get("fsa_id", 1))
     end_device_indexes: list[int] | None = resolved_parameters.get("end_device_indexes", None)
@@ -208,7 +210,7 @@ async def action_create_der_control(  # noqa: C901
     session: AsyncSession,
     envoy_client: EnvoyAdminClient,
     active_test_procedure: ActiveTestProcedure,
-):
+) -> None:
 
     start_time: datetime = resolved_parameters["start"]
     duration_seconds: int = resolved_parameters["duration_seconds"]
@@ -333,7 +335,7 @@ async def action_create_der_control(  # noqa: C901
         active_test_procedure.resource_annotations.der_control_ids_by_alias[annotation] = latest_site_control_id
 
 
-async def action_cancel_active_controls(envoy_client: EnvoyAdminClient):
+async def action_cancel_active_controls(envoy_client: EnvoyAdminClient) -> None:
     control_groups_response = await envoy_client.get_all_site_control_groups()
     if control_groups_response.site_control_groups:
         for g in control_groups_response.site_control_groups:
@@ -349,7 +351,7 @@ async def action_cancel_active_controls(envoy_client: EnvoyAdminClient):
 
 async def action_set_comms_rate(
     resolved_parameters: dict[str, Any], session: AsyncSession, envoy_client: EnvoyAdminClient
-):
+) -> None:
     dcap_poll_seconds: int | None = resolved_parameters.get("dcap_poll_seconds", None)
     edev_list_poll_seconds: int | None = resolved_parameters.get("edev_list_poll_seconds", None)
     fsa_list_poll_seconds: int | None = resolved_parameters.get("fsa_list_poll_seconds", None)
@@ -394,7 +396,7 @@ async def action_set_comms_rate(
 
 async def action_register_end_device(
     active_test_procedure: ActiveTestProcedure, resolved_parameters: dict[str, Any], session: AsyncSession
-):
+) -> None:
     """
     Register an end device for the test. Skip if a site with the same lfdi already exists, allowing the action to be
     re-run in playlist mode where site data is preserved between tests.
@@ -441,12 +443,14 @@ async def action_register_end_device(
     await session.commit()
 
 
-def action_communications_status(active_test_procedure: ActiveTestProcedure, resolved_parameters: dict[str, Any]):
+def action_communications_status(
+    active_test_procedure: ActiveTestProcedure, resolved_parameters: dict[str, Any]
+) -> None:
     comms_enabled: bool = resolved_parameters["enabled"]
     active_test_procedure.communications_disabled = not comms_enabled
 
 
-async def action_edev_registration_links(resolved_parameters: dict[str, Any], envoy_client: EnvoyAdminClient):
+async def action_edev_registration_links(resolved_parameters: dict[str, Any], envoy_client: EnvoyAdminClient) -> None:
     """Implements edev-registration-links action"""
     links_enabled: bool = resolved_parameters["enabled"]
 
@@ -455,7 +459,7 @@ async def action_edev_registration_links(resolved_parameters: dict[str, Any], en
 
 async def action_remove_function_set_assignment(
     resolved_parameters: dict[str, Any], session: AsyncSession, envoy_client: EnvoyAdminClient
-):
+) -> None:
     fsa_id: int = resolved_parameters["fsa_id"]  # Mandatory param
 
     # Identify which site control groups have the nominated function set assignment ID - and remove that FSA ID
@@ -473,7 +477,7 @@ async def action_remove_function_set_assignment(
 
 async def apply_action(  # noqa: C901
     action: Action, runner_state: RunnerState, session: AsyncSession, envoy_client: EnvoyAdminClient
-):
+) -> None:
     """Applies the action to the active test procedure.
 
     Actions describe operations such as activate or disabling steps.
@@ -543,7 +547,7 @@ async def apply_actions(
     listener: Listener,
     runner_state: RunnerState,
     envoy_client: EnvoyAdminClient,
-):
+) -> None:
     """Applies all actions for the given listener.
 
     Logs an error if the action was able to be executed.

--- a/src/cactus_runner/app/action.py
+++ b/src/cactus_runner/app/action.py
@@ -1,6 +1,6 @@
 import logging
 import math
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any
 
@@ -98,7 +98,7 @@ async def action_enable_steps(
     for listener in active_test_procedure.listeners:
         if listener.step in steps_to_enable:
             logger.info(f"ACTION enable-steps: Enabling step {listener.step}")
-            dt_now = datetime.now(tz=timezone.utc)
+            dt_now = datetime.now(tz=UTC)
             listener.enabled_time = dt_now
             active_test_procedure.step_status[listener.step].started_at = dt_now
 
@@ -130,7 +130,7 @@ async def action_remove_steps(
     for listener in listeners_to_remove:
         logger.info(f"ACTION remove-steps: Removing listener: {listener}")
         active_test_procedure.listeners.remove(listener)  # mutate the original listeners list
-        active_test_procedure.step_status[listener.step].completed_at = datetime.now(tz=timezone.utc)
+        active_test_procedure.step_status[listener.step].completed_at = datetime.now(tz=UTC)
 
 
 async def action_finish_test(runner_state: RunnerState, session: AsyncSession):
@@ -146,7 +146,7 @@ async def action_set_default_der_control(
     export_limit_watts = resolved_parameters.get("opModExpLimW", None)
     gen_limit_watts = resolved_parameters.get("opModGenLimW", None)
     load_limit_watts = resolved_parameters.get("opModLoadLimW", None)
-    setGradW = resolved_parameters.get("setGradW", None)
+    set_grad_w = resolved_parameters.get("setGradW", None)
     cancelled = resolved_parameters.get("cancelled", False)
     default_val: UpdateDefaultValue | None = UpdateDefaultValue(value=None) if cancelled else None
 
@@ -174,7 +174,7 @@ async def action_set_default_der_control(
             load_limit_watts=(
                 UpdateDefaultValue(value=load_limit_watts) if load_limit_watts is not None else default_val
             ),
-            ramp_rate_percent_per_second=UpdateDefaultValue(value=setGradW) if setGradW is not None else default_val,
+            ramp_rate_percent_per_second=UpdateDefaultValue(value=set_grad_w) if set_grad_w is not None else default_val,
         ),
     )
 
@@ -236,7 +236,7 @@ async def action_create_der_control(  # noqa: C901
         # We could just use the current count of DERControls but that will recycle between test runs - not ideal
         # so we ALSO combine that with a timestamp to get a 64 bit display_id
         existing_control_count = await count_all_site_controls_with_cancelled(session, site_id=None)
-        now_seconds = int(datetime.now(timezone.utc).timestamp())
+        now_seconds = int(datetime.now(UTC).timestamp())
         display_id = existing_control_count << 32 | (now_seconds & 0xFFFFFFFF)
 
     if len(site_ids) > 1 and annotation:
@@ -339,9 +339,9 @@ async def action_cancel_active_controls(envoy_client: EnvoyAdminClient):
         for g in control_groups_response.site_control_groups:
             await envoy_client.delete_site_controls_in_range(
                 g.site_control_group_id,
-                datetime(2000, 1, 1, tzinfo=timezone.utc),
+                datetime(2000, 1, 1, tzinfo=UTC),
                 datetime(
-                    2100, 1, 1, tzinfo=timezone.utc
+                    2100, 1, 1, tzinfo=UTC
                 ),  # If this is still in use in 2100... I hope you guys sorted out that climate change thing.
                 # Sorry, some of us were trying. Sincerely people in 2025
             )
@@ -403,7 +403,7 @@ async def action_register_end_device(
     registration_pin: int | None = resolved_parameters.get("registration_pin", None)
     aggregator_lfdi: str | None = resolved_parameters.get("aggregator_lfdi", None)
     aggregator_sfdi: int | None = resolved_parameters.get("aggregator_sfdi", None)
-    now = datetime.now(tz=timezone.utc)
+    now = datetime.now(tz=UTC)
 
     lfdi: str
     sfdi: int
@@ -533,7 +533,7 @@ async def apply_action(
 
     except Exception as exc:
         logger.error(f"Failed executing action {action}", exc_info=exc)
-        raise FailedActionError(f"Failed executing action {action.type}")
+        raise FailedActionError(f"Failed executing action {action.type}") from None
 
     raise UnknownActionError(f"Unrecognised action '{action.type}'. This is a problem with the test definition")
 

--- a/src/cactus_runner/app/auth.py
+++ b/src/cactus_runner/app/auth.py
@@ -8,8 +8,8 @@ from envoy.server.api.depends.lfdi_auth import (
     is_valid_sha256,
 )
 
-from cactus_runner.app.shared import APPKEY_INITIALISED_CERTS
 from cactus_runner.app import env
+from cactus_runner.app.shared import APPKEY_INITIALISED_CERTS
 
 logger = logging.getLogger(__name__)
 

--- a/src/cactus_runner/app/check.py
+++ b/src/cactus_runner/app/check.py
@@ -64,7 +64,7 @@ class FailedCheckError(Exception):
 class SiteReadingTypeProperty:
     name: str
 
-    def __init__(self, name: str):
+    def __init__(self, name: str) -> None:
         self.name = name
 
 
@@ -165,7 +165,7 @@ class SoftChecker:
 
     _failures: list[CheckResult]
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._failures = []
 
     def add(self, msg: str) -> None:
@@ -901,7 +901,7 @@ async def do_check_reading_type_mrids_match_pen(site_reading_types: Sequence[Sit
 
 
 async def do_check_site_readings_and_params(
-    session,
+    session: AsyncSession,
     resolved_parameters: dict[str, Any],
     pen: int,
     uom: UomType,

--- a/src/cactus_runner/app/check.py
+++ b/src/cactus_runner/app/check.py
@@ -895,7 +895,7 @@ async def do_check_reading_type_mrids_match_pen(site_reading_types: Sequence[Sit
         return CheckResult(
             True,
             "All MRIDS and group MRIDS for the site readings types match the supplied Private Enterprise Number (PEN).",
-        )  # noqa: E501
+        )
 
     return CheckResult(True, None)
 

--- a/src/cactus_runner/app/check.py
+++ b/src/cactus_runner/app/check.py
@@ -226,7 +226,7 @@ def check_all_steps_complete(
         return CheckResult(True, None)
 
 
-async def check_end_device_contents(
+async def check_end_device_contents(  # noqa: C901
     active_test_procedure: ActiveTestProcedure, session: AsyncSession, resolved_parameters: dict[str, Any]
 ) -> CheckResult:
     """Implements the end-device-contents check
@@ -387,7 +387,7 @@ def do_field_exists_check(
         soft_checker.add(f"{field.alias} MUST be unset but is currently specified as: {actual_value}")
 
 
-async def check_der_settings_contents(
+async def check_der_settings_contents(  # noqa: C901
     session: AsyncSession, resolved_parameters: dict[str, ResolvedParam]
 ) -> CheckResult:
     """Implements the der-settings-contents check
@@ -504,7 +504,7 @@ def is_nth_bit_set_properly(value: int, nth_bit: int, expected: bool) -> bool:
     return bool(value & (1 << nth_bit)) is expected
 
 
-async def check_der_status_contents(session: AsyncSession, resolved_parameters: dict[str, Any]) -> CheckResult:
+async def check_der_status_contents(session: AsyncSession, resolved_parameters: dict[str, Any]) -> CheckResult:  # noqa: C901
     """Implements the der-status-contents check
 
     Returns pass if DERStatus has been submitted for the active site and optionally has certain fields set"""
@@ -685,7 +685,7 @@ async def do_check_single_level(
     )
 
     # Step 2: Alias the subquery to access its columns
-    RankedReading = aliased(SiteReading, ranked_subquery)
+    RankedReading = aliased(SiteReading, ranked_subquery)  # noqa: N806
 
     # Step 3: Join with SiteReadingType and filter to only the latest reading per type
     query = (
@@ -1181,7 +1181,7 @@ def match_all_responses(
         return CheckResult(True, f"All DERControl(s) have a Response with a status of {status_str}")
 
 
-async def check_response_contents(
+async def check_response_contents(  # noqa: C901
     resolved_parameters: dict[str, Any], session: AsyncSession, active_test_procedure: ActiveTestProcedure
 ) -> CheckResult:
     """Implements the response-contents check by inspecting the response table for site controls"""
@@ -1369,7 +1369,7 @@ def check_all_polls_at_correct_time(
     return result
 
 
-async def run_check(
+async def run_check(  # noqa: C901
     check: Check,
     active_test_procedure: ActiveTestProcedure,
     session: AsyncSession,

--- a/src/cactus_runner/app/check.py
+++ b/src/cactus_runner/app/check.py
@@ -220,7 +220,7 @@ def check_all_steps_complete(
         failing_active_steps.append(active_listener.step)
 
     if failing_active_steps:
-        return CheckResult(False, f"Steps {", ".join(failing_active_steps)} have not been completed.")
+        return CheckResult(False, f"Steps {', '.join(failing_active_steps)} have not been completed.")
     else:
         return CheckResult(True, None)
 
@@ -592,7 +592,6 @@ async def do_check_readings_for_types(
 
     """
     if minimum_count is not None:
-
         if site_reading_types:
             srt_ids = [srt.site_reading_type_id for srt in site_reading_types]
             results = await session.execute(
@@ -838,7 +837,7 @@ async def do_check_readings_on_minute_boundary(
         results = await session.execute(
             select(SiteReading.time_period_start).where(SiteReading.site_reading_type_id.in_(srt_ids))
         )
-        on_minute_boundary = [timestamp_on_minute_boundary(time_period_start) for time_period_start, in results.all()]
+        on_minute_boundary = [timestamp_on_minute_boundary(time_period_start) for (time_period_start,) in results.all()]
         aligned_count = on_minute_boundary.count(True)
         total_count = len(on_minute_boundary)
 
@@ -1393,7 +1392,6 @@ async def run_check(
     pen: int = active_test_procedure.pen
     try:
         match check.type:
-
             case "all-steps-complete":
                 check_result = check_all_steps_complete(active_test_procedure, resolved_parameters)
 

--- a/src/cactus_runner/app/check.py
+++ b/src/cactus_runner/app/check.py
@@ -1,9 +1,10 @@
 import http
 import logging
 import re
+from collections.abc import Iterable, Sequence
 from datetime import datetime, timedelta
 from itertools import chain
-from typing import Annotated, Any, Iterable, Optional, Sequence
+from typing import Annotated, Any
 
 import pydantic
 import pydantic.alias_generators
@@ -247,11 +248,11 @@ async def check_end_device_contents(
     if has_connection_point_id and not site.nmi:
         return CheckResult(False, f"EndDevice {site.site_id} has no ConnectionPoint id specified.")
 
-    deviceCategory_anyset: int = int(resolved_parameters.get("deviceCategory_anyset", "0"), 16)
-    if deviceCategory_anyset and (deviceCategory_anyset & int(site.device_category)) == 0:
+    device_category_anyset: int = int(resolved_parameters.get("deviceCategory_anyset", "0"), 16)
+    if device_category_anyset and (device_category_anyset & int(site.device_category)) == 0:
         return CheckResult(
             False,
-            f"EndDevice {site.site_id} has none of the expected ({deviceCategory_anyset:b}) deviceCategory bits set.",
+            f"EndDevice {site.site_id} has none of the expected ({device_category_anyset:b}) deviceCategory bits set.",
         )
 
     check_lfdi: bool = resolved_parameters.get("check_lfdi", False)
@@ -581,7 +582,7 @@ async def check_der_status_contents(session: AsyncSession, resolved_parameters: 
 
 
 async def do_check_readings_for_types(
-    session: AsyncSession, site_reading_types: Sequence[SiteReadingType], minimum_count: Optional[int]
+    session: AsyncSession, site_reading_types: Sequence[SiteReadingType], minimum_count: int | None
 ) -> CheckResult:
     """Checks the SiteReading table for a specified set of SiteReadingType ID's. Makes sure that all conditions
     are met. "Valid" is that at least ONE of the site_reading_types supplied meets the conditions
@@ -623,7 +624,7 @@ async def do_check_readings_for_types(
         #
         # If the client breaks these assumptions - they're still getting marked as failing - the error message will
         # just end up being a little less than perfect.
-        total_mups = len(set((srt.group_id for srt in site_reading_types)))
+        total_mups = len(set(srt.group_id for srt in site_reading_types))
         total_mmrs = len(site_reading_types)
 
         if highest_found_count >= minimum_count:
@@ -841,7 +842,7 @@ async def do_check_readings_on_minute_boundary(
         aligned_count = on_minute_boundary.count(True)
         total_count = len(on_minute_boundary)
 
-        total_mups = len(set((srt.group_id for srt in site_reading_types)))
+        total_mups = len(set(srt.group_id for srt in site_reading_types))
         total_mmrs = len(site_reading_types)
 
         if aligned_count != total_count:
@@ -1189,7 +1190,7 @@ async def check_response_contents(
     is_all: bool = resolved_parameters.get("all", False)
     status_filter: int | None = resolved_parameters.get("status", None)
     status_filter_string: str = response_type_to_string(status_filter)
-    subject_tag: Optional[str] = resolved_parameters.get("subject_tag", None)
+    subject_tag: str | None = resolved_parameters.get("subject_tag", None)
 
     # Handle the "all" case separately
     if is_all:
@@ -1444,7 +1445,7 @@ async def run_check(
 
     except Exception as exc:
         logger.error(f"Failed performing check {check}", exc_info=exc)
-        raise FailedCheckError(f"Failed performing check {check}. {exc}")
+        raise FailedCheckError(f"Failed performing check {check}. {exc}") from None
 
     if check_result is None:
         raise UnknownCheckError(f"Unrecognised check '{check.type}'. This is a problem with the test definition")

--- a/src/cactus_runner/app/envoy_admin_client.py
+++ b/src/cactus_runner/app/envoy_admin_client.py
@@ -41,7 +41,7 @@ logger.setLevel(logging.INFO)
 
 
 class SecretString:
-    def __init__(self, secret: str):
+    def __init__(self, secret: str) -> None:
         self._secret = secret
 
     def __str__(self) -> str:
@@ -70,7 +70,7 @@ class EnvoyAdminClient:
     application cleanup to ensure proper session teardown.
     """
 
-    def __init__(self, base_url: StrOrURL, auth_params: EnvoyAdminClientAuthParams, timeout: int = 30):
+    def __init__(self, base_url: StrOrURL, auth_params: EnvoyAdminClientAuthParams, timeout: int = 30) -> None:
         self._base_url = base_url
         self._timeout = ClientTimeout(total=timeout)
         self._session: ClientSession = ClientSession(
@@ -80,7 +80,7 @@ class EnvoyAdminClient:
             auth=BasicAuth(login=auth_params.username, password=auth_params.password),
         )
 
-    async def close_session(self):
+    async def close_session(self) -> None:
         await self._session.close()
 
     async def get_aggregators(self) -> AggregatorPageResponse:

--- a/src/cactus_runner/app/envoy_common.py
+++ b/src/cactus_runner/app/envoy_common.py
@@ -1,7 +1,7 @@
 import logging
+from collections.abc import Sequence
 from enum import IntEnum
 from itertools import chain
-from typing import Sequence
 
 from envoy.server.model.archive.doe import (
     ArchiveDynamicOperatingEnvelope,
@@ -137,7 +137,7 @@ async def get_site_readings(session: AsyncSession, site_reading_type: SiteReadin
 
     response = await session.execute(
         select(SiteReading)
-        .where((SiteReading.site_reading_type_id == site_reading_type.site_reading_type_id))
+        .where(SiteReading.site_reading_type_id == site_reading_type.site_reading_type_id)
         .order_by(SiteReading.created_time.asc())
     )
 

--- a/src/cactus_runner/app/evaluator.py
+++ b/src/cactus_runner/app/evaluator.py
@@ -1,19 +1,18 @@
+import dataclasses
 from typing import Any
 
-import dataclasses
-
-from cactus_runner.app import resolvers
-
+from cactus_test_definitions.errors import UnresolvableVariableError
 from cactus_test_definitions.variable_expressions import (
+    BaseExpression,
     Constant,
     Expression,
     NamedVariable,
     NamedVariableType,
     OperationType,
-    BaseExpression,
 )
-from cactus_test_definitions.errors import UnresolvableVariableError
 from sqlalchemy.ext.asyncio import AsyncSession
+
+from cactus_runner.app import resolvers
 
 
 @dataclasses.dataclass

--- a/src/cactus_runner/app/evaluator.py
+++ b/src/cactus_runner/app/evaluator.py
@@ -108,7 +108,7 @@ async def resolve_variable(session: AsyncSession, v: NamedVariable | Expression 
             raise ValueError(f"Unsupported operation {v.operation} ({int(v.operation)})")
 
         except Exception as exc:
-            raise UnresolvableVariableError(f"Unable to apply {v.operation} to operands: {exc}")
+            raise UnresolvableVariableError(f"Unable to apply {v.operation} to operands: {exc}") from exc
     else:
         raise UnresolvableVariableError(f"Unsupported variable type {type(v)}")
 

--- a/src/cactus_runner/app/evaluator.py
+++ b/src/cactus_runner/app/evaluator.py
@@ -23,12 +23,12 @@ class ResolvedParam:
     original_expression: BaseExpression | None = None
 
 
-def is_resolvable_variable(v: Any) -> bool:
+def is_resolvable_variable(v: Any) -> bool:  # noqa: ANN401
     """Returns True if the supplied value is a variable definition that requires resolving"""
     return isinstance(v, NamedVariable) or isinstance(v, Expression) or isinstance(v, Constant)
 
 
-async def resolve_variable(session: AsyncSession, v: NamedVariable | Expression | Constant) -> Any:
+async def resolve_variable(session: AsyncSession, v: NamedVariable | Expression | Constant) -> Any:  # noqa: C901, ANN401
     """Attempts to resolve the specified variable (potentially from the database)
 
     raises UnresolvableVariableError if any errors are encountered
@@ -107,8 +107,8 @@ async def resolve_variable(session: AsyncSession, v: NamedVariable | Expression 
                     return lhs >= rhs
             raise ValueError(f"Unsupported operation {v.operation} ({int(v.operation)})")
 
-        except Exception as exc:
-            raise UnresolvableVariableError(f"Unable to apply {v.operation} to operands: {exc}") from exc
+        except Exception as err:
+            raise UnresolvableVariableError(f"Unable to apply {v.operation} to operands: {err}") from err
     else:
         raise UnresolvableVariableError(f"Unsupported variable type {type(v)}")
 

--- a/src/cactus_runner/app/event.py
+++ b/src/cactus_runner/app/event.py
@@ -109,7 +109,6 @@ async def is_listener_triggerable(
 
     # If this listener is a wait event and the current trigger is time based
     if listener.event.type == "wait" and trigger.type == EventTriggerType.TIME:
-
         resolved_params = await evaluator.resolve_variable_expressions_from_parameters(
             session, listener.event.parameters
         )
@@ -169,7 +168,6 @@ async def handle_event_trigger(
     triggered_listeners: list[Listener] = []
     listeners_to_eval = active_test_procedure.listeners.copy()  # We copy this as the underlying list might mutate
     for listener in listeners_to_eval:
-
         if await is_listener_triggerable(listener, trigger, session):
             logger.info(f"handle_event_trigger: Matched Step {listener.step} for {trigger}")
 

--- a/src/cactus_runner/app/event.py
+++ b/src/cactus_runner/app/event.py
@@ -63,7 +63,7 @@ class EventTrigger:
     client_request: ClientRequestDetails | None  # Only specified if type == CLIENT_REQUEST
 
 
-async def is_listener_triggerable(
+async def is_listener_triggerable(  # noqa: C901
     listener: Listener,
     trigger: EventTrigger,
     session: AsyncSession,

--- a/src/cactus_runner/app/event.py
+++ b/src/cactus_runner/app/event.py
@@ -192,9 +192,7 @@ async def handle_event_trigger(
 
 def generate_time_trigger() -> EventTrigger:
     """Generates an EventTrigger representing a poll of the TIME event"""
-    return EventTrigger(
-        type=EventTriggerType.TIME, time=datetime.now(UTC), single_listener=False, client_request=None
-    )
+    return EventTrigger(type=EventTriggerType.TIME, time=datetime.now(UTC), single_listener=False, client_request=None)
 
 
 def generate_client_request_trigger(request: web.Request, mount_point: str, before_serving: bool) -> EventTrigger:

--- a/src/cactus_runner/app/event.py
+++ b/src/cactus_runner/app/event.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from enum import IntEnum, auto
 from http import HTTPMethod
 
@@ -193,7 +193,7 @@ async def handle_event_trigger(
 def generate_time_trigger() -> EventTrigger:
     """Generates an EventTrigger representing a poll of the TIME event"""
     return EventTrigger(
-        type=EventTriggerType.TIME, time=datetime.now(timezone.utc), single_listener=False, client_request=None
+        type=EventTriggerType.TIME, time=datetime.now(UTC), single_listener=False, client_request=None
     )
 
 
@@ -227,7 +227,7 @@ def generate_client_request_trigger(request: web.Request, mount_point: str, befo
     trigger_type = EventTriggerType.CLIENT_REQUEST_BEFORE if before_serving else EventTriggerType.CLIENT_REQUEST_AFTER
     return EventTrigger(
         type=trigger_type,
-        time=datetime.now(timezone.utc),
+        time=datetime.now(UTC),
         single_listener=True,
         client_request=ClientRequestDetails(HTTPMethod(request.method), path_without_mount, query_start),
     )
@@ -236,5 +236,5 @@ def generate_client_request_trigger(request: web.Request, mount_point: str, befo
 def generate_proceed_trigger() -> EventTrigger:
     """Generates an EventTrigger representing a proceed signal sent by the UI"""
     return EventTrigger(
-        type=EventTriggerType.PROCEED, time=datetime.now(timezone.utc), single_listener=True, client_request=None
+        type=EventTriggerType.PROCEED, time=datetime.now(UTC), single_listener=True, client_request=None
     )

--- a/src/cactus_runner/app/finalize.py
+++ b/src/cactus_runner/app/finalize.py
@@ -199,7 +199,7 @@ async def generate_json_reporting_data(
     reading_counts: dict[ReadingType, int],
     sites: list[Site],
     timeline: timeline.Timeline | None,
-    errors,
+    errors: list[str],
     version: int = 1,
     set_max_w_varied: bool = False,
 ) -> str | None:

--- a/src/cactus_runner/app/finalize.py
+++ b/src/cactus_runner/app/finalize.py
@@ -5,7 +5,7 @@ import shutil
 import subprocess  # nosec B404
 import tempfile
 import zipfile
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import cast
 
@@ -61,7 +61,7 @@ class DatabaseDumpError(Exception):
     pass
 
 
-class NoActiveTestProcedure(Exception):
+class NoActiveTestProcedureError(Exception):
     pass
 
 
@@ -145,8 +145,8 @@ def write_zip_to_file(
         # Create db dumps (schema + data)
         try:
             connection_string = get_postgres_dsn().replace("+psycopg", "")
-        except DatabaseNotInitialisedError:
-            raise DatabaseDumpError("Database is not initialised and therefore cannot be dumped")
+        except DatabaseNotInitialisedError as err:
+            raise DatabaseDumpError("Database is not initialised and therefore cannot be dumped") from err
         exectuable_name = "pg_dump"
         for dump_args, dump_filename in [
             (["--schema-only", "--no-owner", "--no-privileges"], f"EnvoyDBSchema{filename_infix}.dump"),
@@ -203,7 +203,7 @@ async def generate_json_reporting_data(
     version: int = 1,
     set_max_w_varied: bool = False,
 ) -> str | None:
-    created_at = datetime.now(timezone.utc)
+    created_at = datetime.now(UTC)
 
     try:
         # Repack readings into something serializable
@@ -234,19 +234,19 @@ async def generate_json_reporting_data(
 
 async def finish_active_test(runner_state: RunnerState, session: AsyncSession) -> Path:
     """For the specified RunnerState - move the active test into a "Finished" state by writing the final ZIP
-    to a temporary file. Raises NoActiveTestProcedure if there isn't an active test procedure for the specified
+    to a temporary file. Raises NoActiveTestProcedureError if there isn't an active test procedure for the specified
     RunnerState
 
     If the active test is already finished - this will have no effect and will return the cached finished_zip_path
 
     Populates and then returns the finished_zip_path for the active test procedure"""
 
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     errors: list[str] = []  # For capturing basic error information to encode in the zip to alert about missing content
 
     active_test_procedure = runner_state.active_test_procedure
     if not active_test_procedure:
-        raise NoActiveTestProcedure()
+        raise NoActiveTestProcedureError()
 
     if active_test_procedure.is_finished():
         logger.info(

--- a/src/cactus_runner/app/finalize.py
+++ b/src/cactus_runner/app/finalize.py
@@ -156,7 +156,7 @@ def write_zip_to_file(
             # This command isn't constructed from user input, so it should be safe to use subprocess.run (nosec B603)
             command = [exectuable_name, f"--dbname={connection_string}", "-f", dump_file, "--no-password"] + dump_args
             try:
-                subprocess.run(command)  # nosec B603
+                subprocess.run(command)  # noqa: S603
             except FileNotFoundError as exc:
                 logger.error(
                     f"Unable to create database snapshot ('{exectuable_name}' executable not found). Did you forget to install 'postgresql-client'?",  # noqa: E501
@@ -232,7 +232,7 @@ async def generate_json_reporting_data(
     return json_reporting_data
 
 
-async def finish_active_test(runner_state: RunnerState, session: AsyncSession) -> Path:
+async def finish_active_test(runner_state: RunnerState, session: AsyncSession) -> Path:  # noqa: C901
     """For the specified RunnerState - move the active test into a "Finished" state by writing the final ZIP
     to a temporary file. Raises NoActiveTestProcedureError if there isn't an active test procedure for the specified
     RunnerState

--- a/src/cactus_runner/app/finalize.py
+++ b/src/cactus_runner/app/finalize.py
@@ -156,7 +156,7 @@ def write_zip_to_file(
             # This command isn't constructed from user input, so it should be safe to use subprocess.run (nosec B603)
             command = [exectuable_name, f"--dbname={connection_string}", "-f", dump_file, "--no-password"] + dump_args
             try:
-                subprocess.run(command)  # noqa: S603
+                subprocess.run(command)  # nosec B603  # noqa: S603
             except FileNotFoundError as exc:
                 logger.error(
                     f"Unable to create database snapshot ('{exectuable_name}' executable not found). Did you forget to install 'postgresql-client'?",  # noqa: E501
@@ -214,7 +214,7 @@ async def generate_json_reporting_data(
             for k, v in reading_counts.items()
         ]
 
-        reporting_data = ReportingData.v(version)(
+        reporting_data = ReportingData.v(version)(  # type: ignore[call-arg]
             created_at=created_at,
             runner_state=runner_state,
             check_results=check_results,

--- a/src/cactus_runner/app/handler.py
+++ b/src/cactus_runner/app/handler.py
@@ -1,7 +1,7 @@
 import http
 import logging
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import cast
 
@@ -115,7 +115,7 @@ async def attempt_start_for_state(runner_state: RunnerState, envoy_client: Envoy
         )
 
     # Update last client interaction
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     runner_state.client_interactions.append(
         ClientInteraction(interaction_type=ClientInteractionType.TEST_PROCEDURE_START, timestamp=now)
     )
@@ -142,7 +142,7 @@ async def attempt_start_for_state(runner_state: RunnerState, envoy_client: Envoy
         StartResponseBody(
             status="Test procedure started.",
             test_procedure=active_test_procedure.name,
-            timestamp=datetime.now(timezone.utc),
+            timestamp=datetime.now(UTC),
         ).to_json(),
     )
 
@@ -188,7 +188,7 @@ async def setup_test_procedure_from_request(
         name=run_request.test_definition.test_procedure_id,
         definition=definition,
         csip_aus_version=run_request.run_group.csip_aus_version,
-        initialised_at=datetime.now(tz=timezone.utc),
+        initialised_at=datetime.now(tz=UTC),
         started_at=None,  # Test hasn't started yet
         listeners=listeners,
         step_status=step_status,
@@ -215,7 +215,7 @@ async def initialize_next_test(
     """Initialize the next test procedure in a playlist."""
     runner_state.client_interactions.append(
         ClientInteraction(
-            interaction_type=ClientInteractionType.TEST_PROCEDURE_INIT, timestamp=datetime.now(timezone.utc)
+            interaction_type=ClientInteractionType.TEST_PROCEDURE_INIT, timestamp=datetime.now(UTC)
         )
     )
 
@@ -328,7 +328,7 @@ async def initialise_handler(request: web.Request) -> web.Response:  # noqa: C90
     # Update last client interaction
     request.app[APPKEY_RUNNER_STATE].client_interactions.append(
         ClientInteraction(
-            interaction_type=ClientInteractionType.TEST_PROCEDURE_INIT, timestamp=datetime.now(timezone.utc)
+            interaction_type=ClientInteractionType.TEST_PROCEDURE_INIT, timestamp=datetime.now(UTC)
         )
     )
 
@@ -461,7 +461,7 @@ async def initialise_handler(request: web.Request) -> web.Response:  # noqa: C90
     body = InitResponseBody(
         status="Test procedure initialised.",
         test_procedure=run_request.test_definition.test_procedure_id.value,
-        timestamp=datetime.now(timezone.utc),
+        timestamp=datetime.now(UTC),
         is_started=is_started,
     )
     return web.Response(status=http.HTTPStatus.CREATED, content_type="application/json", text=body.to_json())
@@ -534,7 +534,7 @@ async def finalize_handler(request: web.Request) -> web.FileResponse | web.Respo
         )
 
         # Determine zip filename
-        generation_timestamp = datetime.now(timezone.utc).replace(microsecond=0)
+        generation_timestamp = datetime.now(UTC).replace(microsecond=0)
         zip_filename = (
             f"CactusTestProcedureArtifacts_{generation_timestamp.isoformat()}_{finalized_test_procedure_name}.zip"
         )
@@ -558,7 +558,7 @@ async def finalize_handler(request: web.Request) -> web.FileResponse | web.Respo
                     runner_state.client_interactions.append(
                         ClientInteraction(
                             interaction_type=ClientInteractionType.TEST_PROCEDURE_INIT,
-                            timestamp=datetime.now(timezone.utc),
+                            timestamp=datetime.now(UTC),
                         )
                     )
                     runner_state.active_test_procedure = await setup_test_procedure_from_request(
@@ -732,7 +732,7 @@ async def proxied_request_handler(request: web.Request) -> web.Response:
         )
 
     # Store timestamp of when the request was received
-    request_timestamp = datetime.now(timezone.utc)
+    request_timestamp = datetime.now(UTC)
 
     # Only proceed if authorized
     if not (DEV_SKIP_AUTHORIZATION_CHECK or auth.request_is_authorized(request=request)):

--- a/src/cactus_runner/app/handler.py
+++ b/src/cactus_runner/app/handler.py
@@ -214,9 +214,7 @@ async def initialize_next_test(
 ) -> None:
     """Initialize the next test procedure in a playlist."""
     runner_state.client_interactions.append(
-        ClientInteraction(
-            interaction_type=ClientInteractionType.TEST_PROCEDURE_INIT, timestamp=datetime.now(UTC)
-        )
+        ClientInteraction(interaction_type=ClientInteractionType.TEST_PROCEDURE_INIT, timestamp=datetime.now(UTC))
     )
 
     prev_test = runner_state.active_test_procedure
@@ -327,9 +325,7 @@ async def initialise_handler(request: web.Request) -> web.Response:  # noqa: C90
 
     # Update last client interaction
     request.app[APPKEY_RUNNER_STATE].client_interactions.append(
-        ClientInteraction(
-            interaction_type=ClientInteractionType.TEST_PROCEDURE_INIT, timestamp=datetime.now(UTC)
-        )
+        ClientInteraction(interaction_type=ClientInteractionType.TEST_PROCEDURE_INIT, timestamp=datetime.now(UTC))
     )
 
     # Reset envoy database

--- a/src/cactus_runner/app/handler.py
+++ b/src/cactus_runner/app/handler.py
@@ -172,8 +172,8 @@ async def setup_test_procedure_from_request(
         definition = TestProcedure.from_yaml(run_request.test_definition.yaml_definition)
         if isinstance(definition, list):
             raise ValueError("Definition must be a TestProcedure instance and not list[TestProcedure]")
-    except Exception as e:
-        raise ValueError(f"Received invalid test procedure definition {e}")
+    except Exception as err:
+        raise ValueError(f"Received invalid test procedure definition {err}") from err
 
     # Create listeners for all test procedure events
     listeners = []

--- a/src/cactus_runner/app/handler.py
+++ b/src/cactus_runner/app/handler.py
@@ -66,7 +66,7 @@ class StartResult:
 
 async def attempt_apply_actions(
     actions: list[Action] | None, runner_state: RunnerState, envoy_client: EnvoyAdminClient
-):
+) -> None:
     if actions:
         async with begin_session() as session:
             for a in actions:

--- a/src/cactus_runner/app/log.py
+++ b/src/cactus_runner/app/log.py
@@ -1,7 +1,7 @@
 import datetime as dt
 import json
 import logging
-from typing import override
+from typing import Any, override
 
 # Changing these log file paths requires updating cactus-deploy logconf.json files - these are baked into built images.
 # In theory, we could try and make this more dynamic but for practical reasons, moving these around shouldn't be a
@@ -45,7 +45,7 @@ class JSONLFormatter(logging.Formatter):
     which is suitable for structured (machine-parsable) log files.
     """
 
-    def __init__(self, *, fmt_keys: dict[str, str] | None = None):
+    def __init__(self, *, fmt_keys: dict[str, str] | None = None) -> None:
         super().__init__()
         self.fmt_keys = fmt_keys if fmt_keys is not None else {}
 
@@ -54,7 +54,7 @@ class JSONLFormatter(logging.Formatter):
         message = self._prepare_log_dict(record)
         return json.dumps(message, default=str)
 
-    def _prepare_log_dict(self, record: logging.LogRecord):
+    def _prepare_log_dict(self, record: logging.LogRecord) -> dict[str, Any]:
         always_fields = {
             "message": record.getMessage(),
             "timestamp": dt.datetime.fromtimestamp(record.created, tz=dt.UTC).isoformat(),

--- a/src/cactus_runner/app/log.py
+++ b/src/cactus_runner/app/log.py
@@ -57,7 +57,7 @@ class JSONLFormatter(logging.Formatter):
     def _prepare_log_dict(self, record: logging.LogRecord):
         always_fields = {
             "message": record.getMessage(),
-            "timestamp": dt.datetime.fromtimestamp(record.created, tz=dt.timezone.utc).isoformat(),
+            "timestamp": dt.datetime.fromtimestamp(record.created, tz=dt.UTC).isoformat(),
         }
 
         if record.exc_info is not None:
@@ -95,7 +95,7 @@ def read_log_file(log_file_path: str) -> str:
 
     Significantly large log files will be truncated"""
     try:
-        with open(log_file_path, "r") as file:
+        with open(log_file_path) as file:
             return file.read(1024 * 1024 * 4)  # Limit to 4MB so we don't over fetch - should be more than enough
     except Exception as exc:
         return f"Error extracting {log_file_path}: {exc}"

--- a/src/cactus_runner/app/main.py
+++ b/src/cactus_runner/app/main.py
@@ -169,7 +169,7 @@ def create_app() -> web.Application:
 
     app[APPKEY_PROXY_LOCK] = asyncio.Lock()
 
-    DEFAULT_PERIOD_SEC = 10  # seconds
+    DEFAULT_PERIOD_SEC = 10  # noqa: N806  # seconds
     app[APPKEY_PERIOD_SEC] = DEFAULT_PERIOD_SEC  # Frequency of periodic task
 
     # Start the periodic task

--- a/src/cactus_runner/app/main.py
+++ b/src/cactus_runner/app/main.py
@@ -11,6 +11,7 @@ from http import HTTPStatus
 from pathlib import Path
 
 from aiohttp import web
+from aiohttp.typedefs import Handler
 from cactus_schema.runner import uri
 
 from cactus_runner import __version__
@@ -44,7 +45,7 @@ logger = logging.getLogger(__name__)
 
 
 @web.middleware
-async def log_error_middleware(request, handler):
+async def log_error_middleware(request: web.Request, handler: Handler) -> web.StreamResponse:
     try:
         response = await handler(request)
         return response
@@ -68,7 +69,7 @@ async def log_error_middleware(request, handler):
         )
 
 
-async def periodic_task(app: web.Application):
+async def periodic_task(app: web.Application) -> None:
     """Periodic task called app[APPKEY_PERIOD_SEC]
 
     Args:
@@ -95,7 +96,7 @@ async def periodic_task(app: web.Application):
         await asyncio.sleep(period)
 
 
-async def setup_periodic_task(app: web.Application):
+async def setup_periodic_task(app: web.Application) -> None:
     """Setup periodic task.
 
     The periodic task is accessible through app[APPKEY_PERIODIC_TASKS].
@@ -178,7 +179,7 @@ def create_app() -> web.Application:
     return app
 
 
-def setup_logging(logging_config_file: Path):
+def setup_logging(logging_config_file: Path) -> None:
     with open(logging_config_file) as f:
         config = json.load(f)
 

--- a/src/cactus_runner/app/main.py
+++ b/src/cactus_runner/app/main.py
@@ -7,6 +7,7 @@ import logging.config
 import logging.handlers
 import os
 import traceback
+from collections.abc import AsyncGenerator
 from http import HTTPStatus
 from pathlib import Path
 
@@ -96,7 +97,7 @@ async def periodic_task(app: web.Application) -> None:
         await asyncio.sleep(period)
 
 
-async def setup_periodic_task(app: web.Application) -> None:
+async def setup_periodic_task(app: web.Application) -> AsyncGenerator[None, None]:
     """Setup periodic task.
 
     The periodic task is accessible through app[APPKEY_PERIODIC_TASKS].

--- a/src/cactus_runner/app/precondition.py
+++ b/src/cactus_runner/app/precondition.py
@@ -22,7 +22,7 @@ PLAYLIST_NOTIFICATION_WAIT_SECONDS = 3
 logger = logging.getLogger(__name__)
 
 
-class UnableToApplyDatabasePrecondition(Exception):
+class UnableToApplyDatabasePreconditionError(Exception):
     pass
 
 

--- a/src/cactus_runner/app/readings.py
+++ b/src/cactus_runner/app/readings.py
@@ -218,7 +218,7 @@ def scale_readings(reading_type: SiteReadingType, readings: Sequence[SiteReading
     if not readings:
         raise ValueError("Expected at least 1 entry in readings. Got 0/None")
 
-    def filter_attributes(attributes: dict[str, Any]):
+    def filter_attributes(attributes: dict[str, Any]) -> dict[str, Any]:
         """Removes attributes that start with _.
 
         This is mainly about targeting and removing sqlalchemy attributes

--- a/src/cactus_runner/app/readings.py
+++ b/src/cactus_runner/app/readings.py
@@ -1,6 +1,7 @@
+from collections.abc import Sequence
 from dataclasses import dataclass
 from decimal import Decimal
-from typing import Any, Sequence
+from typing import Any
 
 import pandas as pd
 from envoy.server.model.site_reading import SiteReading, SiteReadingType

--- a/src/cactus_runner/app/requests_archive.py
+++ b/src/cactus_runner/app/requests_archive.py
@@ -136,7 +136,7 @@ def read_request_response_files(request_id: int) -> tuple[str | None, str | None
 
         if request_files:
             try:
-                with open(request_files[0], "r", encoding="utf-8") as f:
+                with open(request_files[0], encoding="utf-8") as f:
                     request_content = f.read()
             except Exception as exc:
                 logger.error(f"Failed to read request file for request_id={request_id}", exc_info=exc)
@@ -145,7 +145,7 @@ def read_request_response_files(request_id: int) -> tuple[str | None, str | None
 
         if response_files:
             try:
-                with open(response_files[0], "r", encoding="utf-8") as f:
+                with open(response_files[0], encoding="utf-8") as f:
                     response_content = f.read()
             except Exception as exc:
                 logger.error(f"Failed to read response file for request_id={request_id}", exc_info=exc)

--- a/src/cactus_runner/app/requests_archive.py
+++ b/src/cactus_runner/app/requests_archive.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 # nosec B108: Safe in short lived K8s pods (one per test, destroyed after run)
 # Alternatives tried: hardcoded paths (permission errors), tempfile (failed on write to zip, issue on finalise?)
-REQUEST_DATA_DIR = Path("/tmp/cactus_request_data")  # nosec B108
+REQUEST_DATA_DIR = Path("/tmp/cactus_request_data")  # noqa: S108
 
 
 def ensure_request_data_dir() -> Path:
@@ -44,7 +44,7 @@ def sanitise_url_to_filename(url: str) -> str:
     return sanitised if sanitised else "root"
 
 
-def write_request_response_files(
+def write_request_response_files(  # noqa: C901
     request_id: int,
     proxy_result: proxy.ProxyResult,
     entry: RequestEntry,

--- a/src/cactus_runner/app/requests_archive.py
+++ b/src/cactus_runner/app/requests_archive.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 # nosec B108: Safe in short lived K8s pods (one per test, destroyed after run)
 # Alternatives tried: hardcoded paths (permission errors), tempfile (failed on write to zip, issue on finalise?)
-REQUEST_DATA_DIR = Path("/tmp/cactus_request_data")  # noqa: S108
+REQUEST_DATA_DIR = Path("/tmp/cactus_request_data")  # nosec B108  # noqa: S108
 
 
 def ensure_request_data_dir() -> Path:

--- a/src/cactus_runner/app/requests_archive.py
+++ b/src/cactus_runner/app/requests_archive.py
@@ -1,7 +1,7 @@
 import logging
-from pathlib import Path
 import re
 import shutil
+from pathlib import Path
 
 from cactus_runner.app import proxy
 from cactus_runner.models import RequestEntry

--- a/src/cactus_runner/app/resolvers.py
+++ b/src/cactus_runner/app/resolvers.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 
 def resolve_named_variable_now() -> dt.datetime:
-    return dt.datetime.now(tz=dt.timezone.utc)
+    return dt.datetime.now(tz=dt.UTC)
 
 
 async def _select_single_site_der_setting(session: AsyncSession, variable_name: str) -> model.SiteDERSetting:

--- a/src/cactus_runner/app/resolvers.py
+++ b/src/cactus_runner/app/resolvers.py
@@ -18,8 +18,8 @@ async def _select_single_site_der_setting(session: AsyncSession, variable_name: 
             sa.select(model.SiteDERSetting).order_by(model.SiteDERSetting.changed_time.desc()).limit(1)
         )
         site_der_setting = response.scalar_one_or_none()
-    except Exception as exc:
-        raise errors.UnresolvableVariableError(f"Unable to fetch DERSetting from database: {exc}")
+    except Exception as err:
+        raise errors.UnresolvableVariableError(f"Unable to fetch DERSetting from database: {err}") from err
 
     if site_der_setting is None:
         raise errors.UnresolvableVariableError(f"Unable to find a suitable DERSetting to resolve {variable_name}")
@@ -34,8 +34,8 @@ async def _select_single_site_der_rating(session: AsyncSession, variable_name: s
             sa.select(model.SiteDERRating).order_by(model.SiteDERRating.changed_time.desc()).limit(1)
         )
         site_der_rating = response.scalar_one_or_none()
-    except Exception as exc:
-        raise errors.UnresolvableVariableError(f"Unable to fetch DERCapability from database: {exc}")
+    except Exception as err:
+        raise errors.UnresolvableVariableError(f"Unable to fetch DERCapability from database: {err}") from err
 
     if site_der_rating is None:
         raise errors.UnresolvableVariableError(f"Unable to find a suitable DERCapability to resolve {variable_name}")

--- a/src/cactus_runner/app/schema_validator.py
+++ b/src/cactus_runner/app/schema_validator.py
@@ -1,6 +1,7 @@
 import logging
 from functools import lru_cache
 from pathlib import Path
+from typing import Any
 
 from lxml import etree
 
@@ -15,13 +16,13 @@ CSIP_AUS_12_DIR = Path(csipaus12.__file__).parent
 class LocalXsdResolver(etree.Resolver):
     """Finds specific XSD files in our local schema directory"""
 
-    def resolve(self, url: str | None, id: str | None, context: etree._ResolverContext) -> etree._InputDocument | None:  # noqa: A002
+    def resolve(self, url: str | None, id: str | None, context: Any) -> Any:  # noqa: A002, ANN401  # type: ignore[override]
         if url == "sep.xsd":
-            return self.resolve_filename(str(CSIP_AUS_12_DIR / "sep.xsd"), context)
+            return self.resolve_filename(str(CSIP_AUS_12_DIR / "sep.xsd"), context)  # type: ignore[attr-defined]
         elif url == "csipaus-core.xsd":
-            return self.resolve_filename(str(CSIP_AUS_12_DIR / "csipaus-core.xsd"), context)
+            return self.resolve_filename(str(CSIP_AUS_12_DIR / "csipaus-core.xsd"), context)  # type: ignore[attr-defined]
         elif url == "csipaus-ext.xsd":
-            return self.resolve_filename(str(CSIP_AUS_12_DIR / "csipaus-ext.xsd"), context)
+            return self.resolve_filename(str(CSIP_AUS_12_DIR / "csipaus-ext.xsd"), context)  # type: ignore[attr-defined]
         return None
 
 

--- a/src/cactus_runner/app/schema_validator.py
+++ b/src/cactus_runner/app/schema_validator.py
@@ -15,7 +15,7 @@ CSIP_AUS_12_DIR = Path(csipaus12.__file__).parent
 class LocalXsdResolver(etree.Resolver):
     """Finds specific XSD files in our local schema directory"""
 
-    def resolve(self, url, id, context):
+    def resolve(self, url: str | None, id: str | None, context: etree._ResolverContext) -> etree._InputDocument | None:  # noqa: A002
         if url == "sep.xsd":
             return self.resolve_filename(str(CSIP_AUS_12_DIR / "sep.xsd"), context)
         elif url == "csipaus-core.xsd":

--- a/src/cactus_runner/app/schema_validator.py
+++ b/src/cactus_runner/app/schema_validator.py
@@ -16,12 +16,12 @@ CSIP_AUS_12_DIR = Path(csipaus12.__file__).parent
 class LocalXsdResolver(etree.Resolver):
     """Finds specific XSD files in our local schema directory"""
 
-    def resolve(self, url: str | None, id: str | None, context: Any) -> Any:  # noqa: A002, ANN401  # type: ignore[override]
-        if url == "sep.xsd":
+    def resolve(self, system_url: str, public_id: str, context: Any = None) -> Any:  # noqa: ANN401
+        if system_url == "sep.xsd":
             return self.resolve_filename(str(CSIP_AUS_12_DIR / "sep.xsd"), context)  # type: ignore[attr-defined]
-        elif url == "csipaus-core.xsd":
+        elif system_url == "csipaus-core.xsd":
             return self.resolve_filename(str(CSIP_AUS_12_DIR / "csipaus-core.xsd"), context)  # type: ignore[attr-defined]
-        elif url == "csipaus-ext.xsd":
+        elif system_url == "csipaus-ext.xsd":
             return self.resolve_filename(str(CSIP_AUS_12_DIR / "csipaus-ext.xsd"), context)  # type: ignore[attr-defined]
         return None
 

--- a/src/cactus_runner/app/schema_validator.py
+++ b/src/cactus_runner/app/schema_validator.py
@@ -34,7 +34,7 @@ def csip_aus_schema() -> etree.XMLSchema:
     parser.resolvers.add(LocalXsdResolver())
 
     # Load schema
-    with open(CSIP_AUS_12_DIR / "csipaus-core.xsd", "r") as fp:
+    with open(CSIP_AUS_12_DIR / "csipaus-core.xsd") as fp:
         xsd_content = fp.read()
     schema_root = etree.XML(xsd_content, parser)
     return etree.XMLSchema(schema_root)

--- a/src/cactus_runner/app/status.py
+++ b/src/cactus_runner/app/status.py
@@ -56,7 +56,7 @@ def _resolve_intflag(bitmap: int | None, flag_type: type[IntFlag]) -> list[str] 
     """Resolve an IntFlag bitmap to a list of active flag names."""
     if bitmap is None:
         return None
-    return [flag.name for flag in flag_type if bitmap & flag]
+    return [flag.name for flag in flag_type if bitmap & flag and flag.name is not None]
 
 
 def _resolve_intenum(value: int | None, enum_type: type[IntEnum]) -> str | None:

--- a/src/cactus_runner/app/status.py
+++ b/src/cactus_runner/app/status.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 from cactus_schema.runner import (
     CriteriaEntry,
@@ -295,7 +295,7 @@ async def get_active_runner_status(
     last_client_interaction: ClientInteraction,
     crop_minutes: int | None = None,  # Allows a partial runner status to be generated for the UI
 ) -> RunnerStatus:
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
 
     step_status: dict[str, StepEventStatus] = {}
     for step_name, step_info in active_test_procedure.step_status.items():
@@ -334,11 +334,11 @@ async def get_active_runner_status(
 
     # Optionally crop request_history to reduce status size for UI
     if crop_minutes is not None:
-        cutoff_time = datetime.now(timezone.utc) - timedelta(minutes=crop_minutes)
+        cutoff_time = datetime.now(UTC) - timedelta(minutes=crop_minutes)
         request_history = [req for req in request_history if req.timestamp >= cutoff_time]
 
     return RunnerStatus(
-        timestamp_status=datetime.now(tz=timezone.utc),
+        timestamp_status=datetime.now(tz=UTC),
         timestamp_initialise=active_test_procedure.initialised_at,
         timestamp_start=active_test_procedure.started_at,
         csip_aus_version=active_test_procedure.csip_aus_version.value,
@@ -358,7 +358,7 @@ async def get_active_runner_status(
 
 def get_runner_status(last_client_interaction: ClientInteraction) -> RunnerStatus:
     return RunnerStatus(
-        timestamp_status=datetime.now(tz=timezone.utc),
+        timestamp_status=datetime.now(tz=UTC),
         timestamp_start=None,
         timestamp_initialise=None,
         csip_aus_version="",

--- a/src/cactus_runner/app/status.py
+++ b/src/cactus_runner/app/status.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import UTC, datetime, timedelta
+from enum import IntEnum, IntFlag
 
 from cactus_schema.runner import (
     CriteriaEntry,
@@ -51,14 +52,14 @@ def _resolve_value_multiplier(value: int | None, multiplier: int | None) -> int 
     return int(value * (10 ** (multiplier if multiplier is not None else 0)))
 
 
-def _resolve_intflag(bitmap: int | None, flag_type) -> list[str] | None:
+def _resolve_intflag(bitmap: int | None, flag_type: type[IntFlag]) -> list[str] | None:
     """Resolve an IntFlag bitmap to a list of active flag names."""
     if bitmap is None:
         return None
     return [flag.name for flag in flag_type if bitmap & flag]
 
 
-def _resolve_intenum(value: int | None, enum_type) -> str | None:
+def _resolve_intenum(value: int | None, enum_type: type[IntEnum]) -> str | None:
     """Resolve an IntEnum integer value to its name string."""
     if value is None:
         return None
@@ -120,7 +121,7 @@ def _build_der_status(status: SiteDERStatus) -> DERStatusInfo:
     )
 
 
-def get_runner_status_summary(step_status: dict[str, StepInfo]):
+def get_runner_status_summary(step_status: dict[str, StepInfo]) -> str:
     completed_steps = sum(s.get_step_status() == StepStatus.RESOLVED for s in step_status.values())
     steps = len(step_status)
     return f"{completed_steps}/{steps} steps complete."

--- a/src/cactus_runner/app/timeline.py
+++ b/src/cactus_runner/app/timeline.py
@@ -82,7 +82,7 @@ def reading_to_watts(srts: Sequence[SiteReadingType], r: SiteReading) -> int:
     raise ValueError(f"Couldn't find SiteReadingType with ID {r.site_reading_type_id}")
 
 
-def entity_to_priority(entity: Any) -> int:
+def entity_to_priority(entity: Any) -> int:  # noqa: ANN401
     """this function will calculate the entity priority which follows these rules:
 
     1) an ArchiveBase (deletion) descendent is ALWAYS lower priority when compared to other types.
@@ -101,7 +101,7 @@ def entity_to_priority(entity: Any) -> int:
         return 2  # normal record
 
 
-def highest_priority_entity(entities: set[Interval]) -> Any:
+def highest_priority_entity(entities: set[Interval]) -> Any:  # noqa: ANN401
     """this function will take the highest priority entity which follows these priorities:
 
     This priority mapping is done by entity_to_priority

--- a/src/cactus_runner/app/timeline.py
+++ b/src/cactus_runner/app/timeline.py
@@ -201,11 +201,9 @@ async def generate_readings_data_stream(
         # Filter out null/zero durations to prevent IntervalTree crashes
         # This is silently dropped here, but is reported as error/warning in the PDF report post-test
         tree.update(
-
-                Interval(r.time_period_start, r.time_period_start + timedelta(seconds=r.time_period_seconds), r)
-                for r in readings
-                if r.time_period_seconds is not None and r.time_period_seconds > 0
-
+            Interval(r.time_period_start, r.time_period_start + timedelta(seconds=r.time_period_seconds), r)
+            for r in readings
+            if r.time_period_seconds is not None and r.time_period_seconds > 0
         )
 
     # Generate all the reading data

--- a/src/cactus_runner/app/timeline.py
+++ b/src/cactus_runner/app/timeline.py
@@ -27,7 +27,6 @@ from cactus_runner.app.envoy_common import (
 
 @dataclass
 class TimelineDataStream(JSONWizard):
-
     label: str  # Descriptive label of this data stream
     offset_watt_values: list[
         int | None
@@ -313,7 +312,6 @@ async def generate_default_control_data_streams(
 
     intervals: list[Interval] = []
     for default_control in all_defaults:
-
         if isinstance(default_control, ArchiveSiteControlGroupDefault):
             # An archive record was active only from when it was last changed and then archived
             start_time = default_control.changed_time

--- a/src/cactus_runner/app/timeline.py
+++ b/src/cactus_runner/app/timeline.py
@@ -1,8 +1,9 @@
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from decimal import Decimal
 from itertools import chain
-from typing import Any, Callable, Sequence, cast
+from typing import Any, cast
 
 from dataclass_wizard import JSONWizard
 from envoy.server.model.archive import ArchiveBase
@@ -200,11 +201,11 @@ async def generate_readings_data_stream(
         # Filter out null/zero durations to prevent IntervalTree crashes
         # This is silently dropped here, but is reported as error/warning in the PDF report post-test
         tree.update(
-            (
+
                 Interval(r.time_period_start, r.time_period_start + timedelta(seconds=r.time_period_seconds), r)
                 for r in readings
                 if r.time_period_seconds is not None and r.time_period_seconds > 0
-            )
+
         )
 
     # Generate all the reading data
@@ -220,7 +221,7 @@ async def generate_control_data_streams(
 ) -> list[TimelineDataStream]:
 
     all_controls = await get_site_controls_active_archived(session)
-    site_control_group_ids: set[int] = set((c.site_control_group_id for c in all_controls))
+    site_control_group_ids: set[int] = set(c.site_control_group_id for c in all_controls)
     all_data_streams: list[TimelineDataStream] = []
 
     # We will enumerate all the controls, batched by the site control group (DERProgram) that they belong to
@@ -402,7 +403,7 @@ async def generate_timeline(
     # Collate the data streams - culling any that don't have at least 1 value
     populated_data_streams = list(
         filter(
-            lambda ds: any((v is not None for v in ds.offset_watt_values)),
+            lambda ds: any(v is not None for v in ds.offset_watt_values),
             chain([site_readings, device_readings], controls, defaults),
         )
     )

--- a/src/cactus_runner/app/timeline.py
+++ b/src/cactus_runner/app/timeline.py
@@ -173,7 +173,7 @@ def generate_offset_watt_values(
         matching_intervals: set[Interval] = tree[current_interval:next_interval]  # type: ignore
         if matching_intervals:
             entity = highest_priority_entity(matching_intervals)
-            for watt_data, fetcher in zip(fetched_data, watt_fetchers):
+            for watt_data, fetcher in zip(fetched_data, watt_fetchers, strict=True):
                 watt_data.append(fetcher(entity))
         else:
             for watt_data in fetched_data:

--- a/src/cactus_runner/app/uri.py
+++ b/src/cactus_runner/app/uri.py
@@ -1,3 +1,6 @@
+WILDCARD = "*"
+
+
 def does_endpoint_match(path: str, match: str) -> bool:
     """Performs all logic for matching an "endpoint" to an incoming request's path.
 
@@ -12,7 +15,6 @@ def does_endpoint_match(path: str, match: str) -> bool:
     """
 
     # If we don't have a wildcard - do an EXACT match
-    WILDCARD = "*"
     if WILDCARD not in match:
         return path == match
 

--- a/src/cactus_runner/app/uri.py
+++ b/src/cactus_runner/app/uri.py
@@ -27,7 +27,7 @@ def does_endpoint_match(path: str, match: str) -> bool:
         return False
 
     # Compare each component
-    for request_component, match_component in zip(request_components, match_components):
+    for request_component, match_component in zip(request_components, match_components, strict=True):
         if match_component != WILDCARD and request_component != match_component:
             return False
 

--- a/src/cactus_runner/client/__init__.py
+++ b/src/cactus_runner/client/__init__.py
@@ -80,8 +80,8 @@ class RunnerClient:
                         "Unexpected response from server. Expected a single object, but received a list."
                     )
                 return init_response_body
-        except Exception as e:
-            raise RunnerClientError(f"Unexpected failure while initialising test {e}.") from e
+        except Exception as err:
+            raise RunnerClientError(f"Unexpected failure while initialising test {err}.") from err
 
     @staticmethod
     async def start(session: ClientSession) -> StartResponseBody:
@@ -95,8 +95,8 @@ class RunnerClient:
                         "Unexpected response from server. Expected a single object, but received a list."
                     )
                 return start_response_body
-        except ConnectionTimeoutError as e:
-            raise RunnerClientError("Unexpected failure while starting test.") from e
+        except ConnectionTimeoutError as err:
+            raise RunnerClientError("Unexpected failure while starting test.") from err
 
     @staticmethod
     async def finalize(session: ClientSession) -> bytes:
@@ -104,8 +104,8 @@ class RunnerClient:
             async with session.post(url=uri.Finalize) as response:
                 await ensure_success_response(response)
                 return await response.read()
-        except ConnectionTimeoutError as e:
-            raise RunnerClientError("Unexpected failure while finalizing test procedure.") from e
+        except ConnectionTimeoutError as err:
+            raise RunnerClientError("Unexpected failure while finalizing test procedure.") from err
 
     @staticmethod
     async def status(session: ClientSession) -> RunnerStatus:
@@ -119,8 +119,8 @@ class RunnerClient:
                         "Unexpected response from server. Expected a single object, but received a list."
                     )
                 return runner_status
-        except ConnectionTimeoutError as e:
-            raise RunnerClientError("Unexpected failure while requesting test procedure status.") from e
+        except ConnectionTimeoutError as err:
+            raise RunnerClientError("Unexpected failure while requesting test procedure status.") from err
 
     @staticmethod
     async def last_interaction(session: ClientSession) -> ClientInteraction:
@@ -133,8 +133,8 @@ class RunnerClient:
             async with session.get(url=uri.Health) as response:
                 await ensure_success_response(response)
                 return True
-        except Exception as e:
-            logger.debug(e)
+        except Exception as err:
+            logger.debug(err)
             return False
 
     @staticmethod
@@ -149,8 +149,8 @@ class RunnerClient:
                         "Unexpected response from server. Expected a single object, but received a list."
                     )
                 return request_data
-        except ConnectionTimeoutError as e:
-            raise RunnerClientError(f"Unexpected failure while retrieving request data for ID: {request_id}") from e
+        except ConnectionTimeoutError as err:
+            raise RunnerClientError(f"Unexpected failure while retrieving request data for ID: {request_id}") from err
 
     @staticmethod
     async def list_requests(session: ClientSession) -> RequestList:
@@ -164,8 +164,8 @@ class RunnerClient:
                         "Unexpected response from server. Expected a single object, but received a list."
                     )
                 return request_list
-        except ConnectionTimeoutError as e:
-            raise RunnerClientError("Unexpected failure while listing request IDs.") from e
+        except ConnectionTimeoutError as err:
+            raise RunnerClientError("Unexpected failure while listing request IDs.") from err
 
     @staticmethod
     async def proceed(session: ClientSession) -> ProceedResponse:
@@ -179,5 +179,5 @@ class RunnerClient:
                         "Unexpected response from server. Expected a single object, but received a list."
                     )
                 return proceed_response
-        except ConnectionTimeoutError as e:
-            raise RunnerClientError("Unexpected failure while sending proceed request to test runner.") from e
+        except ConnectionTimeoutError as err:
+            raise RunnerClientError("Unexpected failure while sending proceed request to test runner.") from err

--- a/src/cactus_runner/client/__init__.py
+++ b/src/cactus_runner/client/__init__.py
@@ -15,12 +15,12 @@ from cactus_schema.runner import (
 )
 from cactus_test_definitions.client import TestProcedureId
 
-__all__ = ["ClientSession", "ClientTimeout", "RunnerClientException", "TestProcedureId", "RunnerClient"]
+__all__ = ["ClientSession", "ClientTimeout", "RunnerClientError", "TestProcedureId", "RunnerClient"]
 
 logger = logging.getLogger(__name__)
 
 
-class RunnerClientException(Exception):
+class RunnerClientError(Exception):
     http_status_code: int | None  # The HTTP status code received (if any) from the underlying client request
     error_message: str | None  # The error message extracted from the underlying client
 
@@ -34,7 +34,7 @@ class RunnerClientException(Exception):
 
 
 async def ensure_success_response(response: ClientResponse) -> None:
-    """Raises a RunnerClientException if the response is NOT a success response (will consume body). Does nothing
+    """Raises a RunnerClientError if the response is NOT a success response (will consume body). Does nothing
     otherwise"""
     if response.status < 200 or response.status > 299:
         try:
@@ -45,7 +45,7 @@ async def ensure_success_response(response: ClientResponse) -> None:
         logger.error(
             f"Received HTTP {response.status} response for {response.request_info.url}. Response: {response_body}"
         )
-        raise RunnerClientException(
+        raise RunnerClientError(
             f"Received HTTP {response.status} response from server. Response: {response_body}",
             http_status_code=response.status,
             error_message=response_body,  # We will just pass along the whole body - expecting plaintext
@@ -76,13 +76,12 @@ class RunnerClient:
                 response_json = await response.text()
                 init_response_body = InitResponseBody.from_json(response_json)
                 if isinstance(init_response_body, list):
-                    raise RunnerClientException(
+                    raise RunnerClientError(
                         "Unexpected response from server. Expected a single object, but received a list."
                     )
                 return init_response_body
         except Exception as e:
-            logger.debug(e)
-            raise RunnerClientException(f"Unexpected failure while initialising test {e}.")
+            raise RunnerClientError(f"Unexpected failure while initialising test {e}.") from e
 
     @staticmethod
     async def start(session: ClientSession) -> StartResponseBody:
@@ -92,13 +91,12 @@ class RunnerClient:
                 json = await response.text()
                 start_response_body = StartResponseBody.from_json(json)
                 if isinstance(start_response_body, list):
-                    raise RunnerClientException(
+                    raise RunnerClientError(
                         "Unexpected response from server. Expected a single object, but received a list."
                     )
                 return start_response_body
         except ConnectionTimeoutError as e:
-            logger.debug(e)
-            raise RunnerClientException("Unexpected failure while starting test.")
+            raise RunnerClientError("Unexpected failure while starting test.") from e
 
     @staticmethod
     async def finalize(session: ClientSession) -> bytes:
@@ -107,8 +105,7 @@ class RunnerClient:
                 await ensure_success_response(response)
                 return await response.read()
         except ConnectionTimeoutError as e:
-            logger.debug(e)
-            raise RunnerClientException("Unexpected failure while finalizing test procedure.")
+            raise RunnerClientError("Unexpected failure while finalizing test procedure.") from e
 
     @staticmethod
     async def status(session: ClientSession) -> RunnerStatus:
@@ -118,13 +115,12 @@ class RunnerClient:
                 json = await response.text()
                 runner_status = RunnerStatus.from_json(json)
                 if isinstance(runner_status, list):
-                    raise RunnerClientException(
+                    raise RunnerClientError(
                         "Unexpected response from server. Expected a single object, but received a list."
                     )
                 return runner_status
         except ConnectionTimeoutError as e:
-            logger.debug(e)
-            raise RunnerClientException("Unexpected failure while requesting test procedure status.")
+            raise RunnerClientError("Unexpected failure while requesting test procedure status.") from e
 
     @staticmethod
     async def last_interaction(session: ClientSession) -> ClientInteraction:
@@ -149,13 +145,12 @@ class RunnerClient:
                 json = await response.text()
                 request_data = RequestData.from_json(json)
                 if isinstance(request_data, list):
-                    raise RunnerClientException(
+                    raise RunnerClientError(
                         "Unexpected response from server. Expected a single object, but received a list."
                     )
                 return request_data
         except ConnectionTimeoutError as e:
-            logger.debug(e)
-            raise RunnerClientException(f"Unexpected failure while retrieving request data for ID: {request_id}")
+            raise RunnerClientError(f"Unexpected failure while retrieving request data for ID: {request_id}") from e
 
     @staticmethod
     async def list_requests(session: ClientSession) -> RequestList:
@@ -165,13 +160,12 @@ class RunnerClient:
                 json = await response.text()
                 request_list = RequestList.from_json(json)
                 if isinstance(request_list, list):
-                    raise RunnerClientException(
+                    raise RunnerClientError(
                         "Unexpected response from server. Expected a single object, but received a list."
                     )
                 return request_list
         except ConnectionTimeoutError as e:
-            logger.debug(e)
-            raise RunnerClientException("Unexpected failure while listing request IDs.")
+            raise RunnerClientError("Unexpected failure while listing request IDs.") from e
 
     @staticmethod
     async def proceed(session: ClientSession) -> ProceedResponse:
@@ -181,10 +175,9 @@ class RunnerClient:
                 json = await response.text()
                 proceed_response = ProceedResponse.from_json(json)
                 if isinstance(proceed_response, list):
-                    raise RunnerClientException(
+                    raise RunnerClientError(
                         "Unexpected response from server. Expected a single object, but received a list."
                     )
                 return proceed_response
         except ConnectionTimeoutError as e:
-            logger.debug(e)
-            raise RunnerClientException("Unexpected failure while sending proceed request to test runner.")
+            raise RunnerClientError("Unexpected failure while sending proceed request to test runner.") from e

--- a/src/cactus_runner/models.py
+++ b/src/cactus_runner/models.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from decimal import Decimal
 from enum import StrEnum
 from pathlib import Path
@@ -177,7 +177,7 @@ class RunnerState:
     request_history: list[RequestEntry] = field(default_factory=list)
     client_interactions: list[ClientInteraction] = field(
         default_factory=lambda: [
-            ClientInteraction(interaction_type=ClientInteractionType.RUNNER_START, timestamp=datetime.now(timezone.utc))
+            ClientInteraction(interaction_type=ClientInteractionType.RUNNER_START, timestamp=datetime.now(UTC))
         ]
     )
 
@@ -636,11 +636,11 @@ class ReportingData:
 
 
 @dataclass(kw_only=True)
-class ReportingData_Base(JSONWizard):
+class ReportingData_Base(JSONWizard):  # noqa: N801
     version: int = field(init=False)
 
     def _classname_to_version(self) -> int:
-        CLASS_NAME_PREFIX = "ReportingData_v"
+        CLASS_NAME_PREFIX = "ReportingData_v"  # noqa: N806
         return int(self.__class__.__name__.split(CLASS_NAME_PREFIX)[1])
 
     def __post_init__(self):
@@ -649,7 +649,7 @@ class ReportingData_Base(JSONWizard):
 
 
 @dataclass(kw_only=True)
-class ReportingData_v1(ReportingData_Base):
+class ReportingData_v1(ReportingData_Base):  # noqa: N801
     """Holds all the data required to generate cactus run report.
 
     This class is serializable with a `to_json()` call. e.g.

--- a/src/cactus_runner/models.py
+++ b/src/cactus_runner/models.py
@@ -631,7 +631,7 @@ class ReportingData:
         raise ValueError(f"Unknown version of ReportingData ({version}).")
 
     @staticmethod
-    def from_json(version, string, **kwargs) -> Any:
+    def from_json(version, string, **kwargs) -> Any:  # noqa: ANN401
         return ReportingData.v(version).from_json(string, **kwargs)
 
 

--- a/src/cactus_runner/models.py
+++ b/src/cactus_runner/models.py
@@ -3,7 +3,7 @@ from datetime import UTC, datetime
 from decimal import Decimal
 from enum import StrEnum
 from pathlib import Path
-from typing import Any
+from typing import Any, Self
 
 from cactus_schema.runner import (
     ClientInteraction,
@@ -236,7 +236,7 @@ class ReadingType(JSONWizard):
     # site: Site | None
 
     @classmethod
-    def from_site_reading_type(cls, srt: SiteReadingType):
+    def from_site_reading_type(cls, srt: SiteReadingType) -> Self:
         """Converts a sqlalchemy SiteReadingType (from envoy) to a serialisable ReadingType"""
         return cls(
             site_reading_type_id=srt.site_reading_type_id,
@@ -326,7 +326,7 @@ class SiteDERRating(JSONWizard):
     doe_modes_supported: DOESupportedMode | None
 
     @classmethod
-    def from_site_der_rating(cls, rating: EnvoySiteDERRating | None):
+    def from_site_der_rating(cls, rating: EnvoySiteDERRating | None) -> Self | None:
         if rating is None:
             return None
         return cls(
@@ -439,7 +439,7 @@ class SiteDERSetting(JSONWizard):
     doe_modes_enabled: DOESupportedMode | None
 
     @classmethod
-    def from_site_der_setting(cls, setting: EnvoySiteDERSetting | None):
+    def from_site_der_setting(cls, setting: EnvoySiteDERSetting | None) -> Self | None:
         if setting is None:
             return None
 
@@ -514,7 +514,7 @@ class SiteDERAvailability(JSONWizard):
     estimated_w_avail_multiplier: int | None
 
     @classmethod
-    def from_site_der_availability(cls, availability: EnvoySiteDERAvailability | None):
+    def from_site_der_availability(cls, availability: EnvoySiteDERAvailability | None) -> Self | None:
         if availability is None:
             return None
         return cls(
@@ -558,7 +558,7 @@ class SiteDERStatus(JSONWizard):
     storage_connect_status_time: datetime | None
 
     @classmethod
-    def from_site_der_status(cls, status: EnvoySiteDERStatus | None):
+    def from_site_der_status(cls, status: EnvoySiteDERStatus | None) -> Self | None:
         if status is None:
             return None
         return None
@@ -576,7 +576,7 @@ class SiteDER(JSONWizard):
     site_der_status: SiteDERStatus | None
 
     @classmethod
-    def from_site_der(cls, site_der: EnvoySiteDER):
+    def from_site_der(cls, site_der: EnvoySiteDER) -> Self:
         return cls(
             site_der_id=site_der.site_der_id,
             site_id=site_der.site_id,
@@ -605,7 +605,7 @@ class Site(JSONWizard):
     site_ders: list[SiteDER]
 
     @classmethod
-    def from_site(cls, site: EnvoySite):
+    def from_site(cls, site: EnvoySite) -> Self:
         return cls(
             site_id=site.site_id,
             nmi=site.nmi,
@@ -625,13 +625,13 @@ class Site(JSONWizard):
 @dataclass
 class ReportingData:
     @staticmethod
-    def v(version: int):
+    def v(version: int) -> "type[ReportingData_Base]":
         if version == 1:
-            return ReportingData_v1
+            return ReportingData_v1  # type: ignore[return-value]
         raise ValueError(f"Unknown version of ReportingData ({version}).")
 
     @staticmethod
-    def from_json(version, string, **kwargs) -> Any:  # noqa: ANN401
+    def from_json(version: int, string: str, **kwargs: Any) -> Any:  # noqa: ANN401
         return ReportingData.v(version).from_json(string, **kwargs)
 
 
@@ -643,7 +643,7 @@ class ReportingData_Base(JSONWizard):  # noqa: N801
         CLASS_NAME_PREFIX = "ReportingData_v"  # noqa: N806
         return int(self.__class__.__name__.split(CLASS_NAME_PREFIX)[1])
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         # Automatically determine the version from the classname, ReportingData_vXXX
         self.version = self._classname_to_version()
 

--- a/src/cactus_runner/models.py
+++ b/src/cactus_runner/models.py
@@ -566,7 +566,6 @@ class SiteDERStatus(JSONWizard):
 
 @dataclass(frozen=True)
 class SiteDER(JSONWizard):
-
     site_der_id: int
     site_id: int
     created_time: datetime
@@ -592,7 +591,6 @@ class SiteDER(JSONWizard):
 
 @dataclass(frozen=True)
 class Site(JSONWizard):
-
     site_id: int
     nmi: str | None
     aggregator_id: int
@@ -626,7 +624,6 @@ class Site(JSONWizard):
 
 @dataclass
 class ReportingData:
-
     @staticmethod
     def v(version: int):
         if version == 1:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,9 @@
 import os
 import shutil
 import unittest.mock as mock
+from collections.abc import Callable, Generator
 from http import HTTPStatus
 from pathlib import Path
-from typing import Callable, Generator
 from urllib.parse import urlparse
 
 import aiohttp.web as web

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -197,9 +197,9 @@ async def cactus_runner_client_with_mount_point(aiohttp_client, envoy_admin_clie
 
 
 @pytest.fixture
-def run_request_generator() -> (
-    Callable[[TestProcedureId, str | None, str | None, CSIPAusVersion, str | None], RunRequest]
-):
+def run_request_generator() -> Callable[
+    [TestProcedureId, str | None, str | None, CSIPAusVersion, str | None], RunRequest
+]:
     """Yields a function for generating a RunRequest when supplied with a TestProcedureId"""
 
     def _generate_run_request(

--- a/tests/integration/test_all_01.py
+++ b/tests/integration/test_all_01.py
@@ -18,7 +18,7 @@ URI_ENCODED_CERT = quote(TEST_CERTIFICATE_PEM.decode())
 async def assert_success_response(response: ClientResponse):
     if response.status < 200 or response.status >= 300:
         body = await response.read()
-        assert False, f"{response.status}: {body}"
+        raise AssertionError(f"{response.status}: {body}")
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/test_all_07.py
+++ b/tests/integration/test_all_07.py
@@ -21,7 +21,7 @@ URI_ENCODED_CERT = quote(TEST_CERTIFICATE_PEM.decode())
 async def assert_success_response(response: ClientResponse):
     if response.status < 200 or response.status >= 300:
         body = await response.read()
-        assert False, f"{response.status}: {body}"
+        raise AssertionError(f"{response.status}: {body}")
 
 
 @pytest.mark.slow

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -28,7 +28,7 @@ from pytest_aiohttp.plugin import TestClient
 
 from cactus_runner.app.database import remove_database_connection
 from cactus_runner.app.requests_archive import ensure_request_data_dir
-from cactus_runner.client import RunnerClient, RunnerClientException
+from cactus_runner.client import RunnerClient, RunnerClientError
 from tests.integration.certificate1 import (
     TEST_CERTIFICATE_PEM as TEST_CERTIFICATE_1_PEM,
 )
@@ -105,7 +105,7 @@ async def test_client_interactions(
     # Interrogate start response (if it's an immediate start - you shouldn't be able to start it - it should be started)
     if expect_immediate_start:
         async with ClientSession(base_url=cactus_runner_client.make_url("/"), timeout=ClientTimeout(30)) as session:
-            with pytest.raises(RunnerClientException):
+            with pytest.raises(RunnerClientError):
                 await RunnerClient.start(session)
     else:
         async with ClientSession(base_url=cactus_runner_client.make_url("/"), timeout=ClientTimeout(30)) as session:
@@ -187,7 +187,7 @@ async def test_client_init_bad_cert_combos(
     )
     async with ClientSession(base_url=cactus_runner_client.make_url("/"), timeout=ClientTimeout(30)) as session:
         # Look for a BAD_REQUEST (http 400)
-        with pytest.raises(RunnerClientException, check=lambda e: "400" in str(e)):
+        with pytest.raises(RunnerClientError, check=lambda e: "400" in str(e)):
             await RunnerClient.initialise(session, run_request)
 
 
@@ -208,7 +208,7 @@ async def test_client_precondition_fails(cactus_runner_client: TestClient, run_r
 
         # This test will expect preconditions to be met (eg registering an EndDevice) - if we try to start now
         # it should fail and report a useful error
-        with pytest.raises(RunnerClientException) as exc_info:
+        with pytest.raises(RunnerClientError) as exc_info:
             await RunnerClient.start(session)
 
         assert exc_info.value.http_status_code == HTTPStatus.PRECONDITION_FAILED

--- a/tests/integration/test_concurrent_requests.py
+++ b/tests/integration/test_concurrent_requests.py
@@ -5,8 +5,8 @@ import pytest
 from aiohttp import ClientSession, ClientTimeout
 from cactus_schema.runner import (
     RunGroup,
-    RunRequest,
     RunnerStatus,
+    RunRequest,
     TestCertificates,
     TestConfig,
     TestDefinition,
@@ -27,7 +27,8 @@ def _make_concurrent_yaml(n: int) -> str:
     """Generates a test YAML with an ENABLE-LISTENERS step triggered by GET /edev, and n listeners on GET /dcap."""
     listener_names = [f"LISTENER-{i}" for i in range(n)]
     enable_steps_block = "\n".join(f"            - {name}" for name in listener_names)
-    listener_steps = "".join(f"""
+    listener_steps = "".join(
+        f"""
   {name}:
     event:
       type: GET-request-received
@@ -38,7 +39,9 @@ def _make_concurrent_yaml(n: int) -> str:
         parameters:
           steps:
             - {name}
-""" for name in listener_names)
+"""
+        for name in listener_names
+    )
     return f"""\
 Description: Proxy lock stress test ({n} concurrent requests)
 Category: Test

--- a/tests/integration/test_playlist.py
+++ b/tests/integration/test_playlist.py
@@ -280,7 +280,7 @@ async def test_playlist_invalid_start_index_rejected(cactus_runner_client: TestC
 
     # Create 3 test requests
     run_requests = []
-    for i in range(3):
+    for _ in range(3):
         rr = run_request_generator(TestProcedureId.ALL_01, agg_cert, None, csip_version, None)
         run_requests.append(rr)
 

--- a/tests/integration/test_playlist.py
+++ b/tests/integration/test_playlist.py
@@ -41,9 +41,9 @@ def verify_zip_contents(zip_data: bytes, expected_test_name: str) -> None:
     # Verify summary contains expected test name
     summary_data = zip_file.read(summary_files[0])
     summary = RunnerStatus.from_json(summary_data.decode())
-    assert (
-        summary.test_procedure_name == expected_test_name
-    ), f"Expected test name '{expected_test_name}', got '{summary.test_procedure_name}'"
+    assert summary.test_procedure_name == expected_test_name, (
+        f"Expected test name '{expected_test_name}', got '{summary.test_procedure_name}'"
+    )
 
 
 @pytest.mark.slow
@@ -309,7 +309,7 @@ async def test_playlist_three_tests(cactus_runner_client: TestClient, run_reques
     for i in range(3):
         rr = run_request_generator(TestProcedureId.ALL_01, agg_cert, None, csip_version, None)
         rr = RunRequest(
-            run_id=f"playlist-test-{i+1}",
+            run_id=f"playlist-test-{i + 1}",
             test_definition=rr.test_definition,
             run_group=rr.run_group,
             test_config=rr.test_config,
@@ -326,7 +326,7 @@ async def test_playlist_three_tests(cactus_runner_client: TestClient, run_reques
         # Verify a test is active
         async with ClientSession(base_url=cactus_runner_client.make_url("/"), timeout=ClientTimeout(60)) as session:
             status = await RunnerClient.status(session)
-            assert status.test_procedure_name == TestProcedureId.ALL_01.value, f"Test {i+1}: Expected active test"
+            assert status.test_procedure_name == TestProcedureId.ALL_01.value, f"Test {i + 1}: Expected active test"
 
         # Make minimum requests to complete test
         await run_all_01_requests(cactus_runner_client)

--- a/tests/unit/app/conftest.py
+++ b/tests/unit/app/conftest.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 
@@ -7,7 +7,7 @@ from cactus_runner.models import ClientInteraction, ClientInteractionType
 
 @pytest.fixture
 def example_client_interaction():
-    return ClientInteraction(interaction_type=ClientInteractionType.RUNNER_START, timestamp=datetime.now(timezone.utc))
+    return ClientInteraction(interaction_type=ClientInteractionType.RUNNER_START, timestamp=datetime.now(UTC))
 
 
 @pytest.fixture

--- a/tests/unit/app/test_action.py
+++ b/tests/unit/app/test_action.py
@@ -82,14 +82,14 @@ def test_ACTION_TYPE_TO_HANDLER_in_sync():
 
     # Make sure we don't have any extra definitions not found in cactus-test-definitions
     for action_type in ACTION_TYPE_TO_HANDLER.keys():
-        assert (
-            action_type in ACTION_PARAMETER_SCHEMA
-        ), f"The action type {action_type} isn't defined in the test definitions (has it been removed/renamed)"
+        assert action_type in ACTION_PARAMETER_SCHEMA, (
+            f"The action type {action_type} isn't defined in the test definitions (has it been removed/renamed)"
+        )
 
     supported_actions = dict(((k, v) for k, v in ACTION_TYPE_TO_HANDLER.items() if v is not None))
-    assert len(set(supported_actions.values())) == len(
-        supported_actions
-    ), "At least 1 action type have listed the same action handler. This is likely a bug"
+    assert len(set(supported_actions.values())) == len(supported_actions), (
+        "At least 1 action type have listed the same action handler. This is likely a bug"
+    )
 
 
 def create_testing_runner_state(listeners: list[Listener]) -> RunnerState:
@@ -125,9 +125,9 @@ async def test_action_enable_steps():
     assert listeners[0].enabled_time.tzinfo, "Need timezone aware datetime"
     assert steps_to_enable == original_steps_to_enable  # Ensure we are not mutating step_to_enable
     for step in steps_to_enable:
-        assert (
-            runner_state.active_test_procedure.step_status[step].get_step_status() == StepStatus.ACTIVE
-        ), "Check we update step_status"
+        assert runner_state.active_test_procedure.step_status[step].get_step_status() == StepStatus.ACTIVE, (
+            "Check we update step_status"
+        )
 
 
 @pytest.mark.parametrize(
@@ -183,9 +183,9 @@ async def test_action_remove_steps(steps_to_disable: list[str], listeners: list[
     assert len(listeners) == 0  # all steps removed from list of listeners
     assert steps_to_disable == original_steps_to_disable  # check we are mutating 'steps_to_diable'
     for step in steps_to_disable:
-        assert (
-            runner_state.active_test_procedure.step_status[step].get_step_status() == StepStatus.RESOLVED
-        ), "Check we update step_status"
+        assert runner_state.active_test_procedure.step_status[step].get_step_status() == StepStatus.RESOLVED, (
+            "Check we update step_status"
+        )
 
 
 @pytest.mark.parametrize(
@@ -933,7 +933,6 @@ async def test_action_create_der_control_with_end_device_indexes(pg_base_config,
 
     # Verify the tagged control ID matches the created control
     async with generate_async_session(pg_base_config) as session:
-
         all_does = (await session.execute(select(DynamicOperatingEnvelope))).scalars().all()
         assert len(all_does) == 4
         assert len(set([d.export_limit_watts for d in all_does])) == 2, "Two sets of opModExpLimW"

--- a/tests/unit/app/test_action.py
+++ b/tests/unit/app/test_action.py
@@ -652,7 +652,7 @@ async def test_action_create_der_control_derp_tag_missing(pg_base_config, envoy_
 
     # Act
     async with generate_async_session(pg_base_config) as session:
-        with pytest.raises(Exception):
+        with pytest.raises(Exception):  # noqa: B017
             await action_create_der_control(resolved_params, session, envoy_admin_client, active_test_procedure)
 
     # Assert
@@ -884,7 +884,7 @@ async def test_action_create_der_control_with_tag_and_edev_indexes(pg_base_confi
 
     # Act
     async with generate_async_session(pg_base_config) as session:
-        with pytest.raises(Exception):
+        with pytest.raises(Exception):  # noqa: B017
             await action_create_der_control(resolved_params, session, envoy_admin_client, active_test_procedure)
 
     # Assert nothing in the DB
@@ -1286,7 +1286,7 @@ async def test_action_remove_function_set_assignment(
         scgs = await get_all_site_control_groups(session)
         assert len(scgs) == len(scg_fsa_ids)
         for idx, original_fsa_id, original_primacy, original_description, site_control_group in zip(
-            range(len(scg_fsa_ids)), scg_fsa_ids, primacies, descriptions, scgs
+            range(len(scg_fsa_ids)), scg_fsa_ids, primacies, descriptions, scgs, strict=True
         ):
             assert site_control_group.primacy == original_primacy
             assert site_control_group.description == original_description

--- a/tests/unit/app/test_action.py
+++ b/tests/unit/app/test_action.py
@@ -1,5 +1,5 @@
 import unittest.mock as mock
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from itertools import product
 from typing import Any
@@ -140,7 +140,7 @@ async def test_action_enable_steps():
                     step="step1",
                     event=Event(type="", parameters={}),
                     actions=[],
-                    enabled_time=datetime(2000, 1, 1, tzinfo=timezone.utc),
+                    enabled_time=datetime(2000, 1, 1, tzinfo=UTC),
                 ),
             ],
         ),
@@ -157,13 +157,13 @@ async def test_action_enable_steps():
                     step="step1",
                     event=Event(type="", parameters={}),
                     actions=[],
-                    enabled_time=datetime(2000, 1, 1, tzinfo=timezone.utc),
+                    enabled_time=datetime(2000, 1, 1, tzinfo=UTC),
                 ),
                 Listener(
                     step="step2",
                     event=Event(type="", parameters={}),
                     actions=[],
-                    enabled_time=datetime(2000, 1, 1, tzinfo=timezone.utc),
+                    enabled_time=datetime(2000, 1, 1, tzinfo=UTC),
                 ),
             ],
         ),
@@ -237,13 +237,13 @@ async def test__apply_action_raise_exception_for_unknown_action_type():
             step="step",
             event=Event(type="GET-request-received", parameters={"endpoint": "/dcap"}),
             actions=[],
-            enabled_time=datetime(2000, 1, 1, tzinfo=timezone.utc),
+            enabled_time=datetime(2000, 1, 1, tzinfo=UTC),
         ),  # no actions for listener
         Listener(
             step="step",
             event=Event(type="GET-request-received", parameters={"endpoint": "/dcap"}),
             actions=[Action(type="enable-steps", parameters={})],
-            enabled_time=datetime(2000, 1, 1, tzinfo=timezone.utc),
+            enabled_time=datetime(2000, 1, 1, tzinfo=UTC),
         ),  # 1 action for listener
         Listener(
             step="step",
@@ -252,7 +252,7 @@ async def test__apply_action_raise_exception_for_unknown_action_type():
                 Action(type="enable-steps", parameters={}),
                 Action(type="remove-steps", parameters={}),
             ],
-            enabled_time=datetime(2000, 1, 1, tzinfo=timezone.utc),
+            enabled_time=datetime(2000, 1, 1, tzinfo=UTC),
         ),  # 2 actions for listener
     ],
 )
@@ -439,7 +439,7 @@ async def test_action_create_der_control_no_group(pg_base_config, envoy_admin_cl
         session.add(generate_class_instance(Site, aggregator_id=1))
         await session.commit()
     resolved_params = {
-        "start": datetime.now(timezone.utc),
+        "start": datetime.now(UTC),
         "duration_seconds": 300,
         "pow_10_multipliers": -1,
         "primacy": 2,
@@ -537,7 +537,7 @@ async def test_action_create_der_control_existing_group(pg_base_config, envoy_ad
         session.add(generate_class_instance(SiteControlGroup, primacy=2, fsa_id=existing_fsa_id))
         await session.commit()
     resolved_params = {
-        "start": datetime.now(timezone.utc),
+        "start": datetime.now(UTC),
         "duration_seconds": 300,
         "pow_10_multipliers": -1,
         "primacy": 2,
@@ -587,7 +587,7 @@ async def test_action_create_der_control_existing_group_with_tag(pg_base_config,
         session.add(generate_class_instance(SiteControlGroup, primacy=2, site_control_group_id=existing_scg_id))
         await session.commit()
     resolved_params = {
-        "start": datetime.now(timezone.utc),
+        "start": datetime.now(UTC),
         "duration_seconds": 300,
         "pow_10_multipliers": -1,
         "randomizeStart_seconds": 0,
@@ -635,7 +635,7 @@ async def test_action_create_der_control_derp_tag_missing(pg_base_config, envoy_
         session.add(generate_class_instance(SiteControlGroup, primacy=2))
         await session.commit()
     resolved_params = {
-        "start": datetime.now(timezone.utc),
+        "start": datetime.now(UTC),
         "duration_seconds": 300,
         "pow_10_multipliers": -1,
         "randomizeStart_seconds": 0,
@@ -686,7 +686,7 @@ async def test_action_create_der_control_control_values(pg_base_config, envoy_ad
         return float(s + offset)
 
     resolved_params = {
-        "start": datetime.now(timezone.utc),
+        "start": datetime.now(UTC),
         "duration_seconds": 300,
         "pow_10_multipliers": -1,
         "primacy": 2,
@@ -734,7 +734,7 @@ async def test_action_create_der_control_with_tag(pg_base_config, envoy_admin_cl
         await session.commit()
     tag = "DERC1"
     resolved_params = {
-        "start": datetime.now(timezone.utc),
+        "start": datetime.now(UTC),
         "duration_seconds": 300,
         "pow_10_multipliers": -1,
         "primacy": 2,
@@ -778,7 +778,7 @@ async def test_action_create_der_control_with_tag_that_supersedes(pg_base_config
         site_ctrl_grp = generate_class_instance(SiteControlGroup, primacy=2, site_control_group_id=1)
         session.add(site_ctrl_grp)
 
-        existing_creation_time = datetime.now(timezone.utc) - timedelta(seconds=20)
+        existing_creation_time = datetime.now(UTC) - timedelta(seconds=20)
 
         existing_derc = generate_class_instance(
             DynamicOperatingEnvelope,
@@ -811,7 +811,7 @@ async def test_action_create_der_control_with_tag_that_supersedes(pg_base_config
 
     inserted_tag = "DERC-NEW"
     resolved_params = {
-        "start": datetime.now(timezone.utc),
+        "start": datetime.now(UTC),
         "duration_seconds": 300,
         "pow_10_multipliers": -1,
         "primacy": 2,
@@ -865,7 +865,7 @@ async def test_action_create_der_control_with_tag_and_edev_indexes(pg_base_confi
         await session.commit()
     tag = "DERC1"
     resolved_params = {
-        "start": datetime.now(timezone.utc),
+        "start": datetime.now(UTC),
         "duration_seconds": 300,
         "pow_10_multipliers": -1,
         "primacy": 2,
@@ -909,7 +909,7 @@ async def test_action_create_der_control_with_end_device_indexes(pg_base_config,
     active_test_procedure = generate_class_instance(ActiveTestProcedure, step_status={}, finished_zip_path=None)
 
     resolved_params_1 = {
-        "start": datetime.now(timezone.utc),
+        "start": datetime.now(UTC),
         "duration_seconds": 300,
         "pow_10_multipliers": -1,
         "primacy": 2,
@@ -917,7 +917,7 @@ async def test_action_create_der_control_with_end_device_indexes(pg_base_config,
         "end_device_indexes": [0, 2],  # These will correspond to site_id 11 and 33
     }
     resolved_params_2 = {
-        "start": datetime.now(timezone.utc),
+        "start": datetime.now(UTC),
         "duration_seconds": 300,
         "pow_10_multipliers": -1,
         "primacy": 2,
@@ -968,7 +968,7 @@ async def test_action_cancel_active_controls(pg_base_config, envoy_admin_client)
                 calculation_log_id=None,
                 site_control_group=site_ctrl_grp,
                 site=site,
-                start_time=datetime.now(timezone.utc),
+                start_time=datetime.now(UTC),
             )
         )
         await session.commit()

--- a/tests/unit/app/test_check.py
+++ b/tests/unit/app/test_check.py
@@ -2,7 +2,7 @@ import dataclasses
 import http
 import re
 import unittest.mock as mock
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from typing import Any, Literal
 
 import pytest
@@ -2141,7 +2141,7 @@ async def test_check_readings_unique(mock_do_check_site_readings_and_params: moc
 
     # Assert
     assert mock_do_check_site_readings_and_params.call_count == len(reading_checks)
-    assert len(set((a.args[2:] for a in mock_do_check_site_readings_and_params.call_args_list))) == len(
+    assert len(set(a.args[2:] for a in mock_do_check_site_readings_and_params.call_args_list)) == len(
         reading_checks
     ), "Each call to do_check_site_readings_and_params should have unique params (ignoring session/resolved_params)"
 
@@ -2263,7 +2263,7 @@ async def test_check_subscription_contents_no_matches(pg_base_config):
     # Fill up the DB with subscriptions
     async with generate_async_session(pg_base_config) as session:
         agg1 = (await session.execute(select(Aggregator).where(Aggregator.aggregator_id == agg_id))).scalar_one()
-        agg2 = Aggregator(aggregator_id=2, name="test2", changed_time=datetime(2022, 11, 22, tzinfo=timezone.utc))
+        agg2 = Aggregator(aggregator_id=2, name="test2", changed_time=datetime(2022, 11, 22, tzinfo=UTC))
         session.add(agg2)
 
         site1 = generate_class_instance(Site, seed=1001, site_id=1, aggregator_id=agg_id)  # Active Site
@@ -2340,7 +2340,7 @@ async def test_check_subscription_contents_success(pg_base_config):
     # Fill up the DB with subscriptions
     async with generate_async_session(pg_base_config) as session:
         agg1 = (await session.execute(select(Aggregator).where(Aggregator.aggregator_id == agg_id))).scalar_one()
-        agg2 = Aggregator(aggregator_id=2, name="test2", changed_time=datetime(2022, 11, 22, tzinfo=timezone.utc))
+        agg2 = Aggregator(aggregator_id=2, name="test2", changed_time=datetime(2022, 11, 22, tzinfo=UTC))
         session.add(agg2)
 
         site1 = generate_class_instance(Site, seed=1001, site_id=1, aggregator_id=agg_id)  # Active Site
@@ -2429,7 +2429,7 @@ async def test_check_subscription_contents_success_unscoped(pg_base_config):
     # Fill up the DB with subscriptions
     async with generate_async_session(pg_base_config) as session:
         agg1 = (await session.execute(select(Aggregator).where(Aggregator.aggregator_id == 1))).scalar_one()
-        agg2 = Aggregator(aggregator_id=2, name="test2", changed_time=datetime(2022, 11, 22, tzinfo=timezone.utc))
+        agg2 = Aggregator(aggregator_id=2, name="test2", changed_time=datetime(2022, 11, 22, tzinfo=UTC))
         session.add(agg2)
 
         site1 = generate_class_instance(Site, seed=1001, site_id=1, aggregator_id=agg_id)  # Active Site
@@ -2527,7 +2527,7 @@ async def test_check_response_contents_latest(pg_base_config):
                 DynamicOperatingEnvelopeResponse,
                 seed=505,
                 response_type=ResponseType.EVENT_CANCELLED,
-                created_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
+                created_time=datetime(2024, 11, 10, tzinfo=UTC),
                 site=site1,
                 dynamic_operating_envelope_id_snapshot=der_control_1.dynamic_operating_envelope_id,
             )
@@ -2539,7 +2539,7 @@ async def test_check_response_contents_latest(pg_base_config):
                 DynamicOperatingEnvelopeResponse,
                 seed=606,
                 response_type=ResponseType.EVENT_COMPLETED,
-                created_time=datetime(2024, 11, 11, tzinfo=timezone.utc),
+                created_time=datetime(2024, 11, 11, tzinfo=UTC),
                 site=site1,
                 dynamic_operating_envelope_id_snapshot=der_control_1.dynamic_operating_envelope_id,
             )
@@ -2550,7 +2550,7 @@ async def test_check_response_contents_latest(pg_base_config):
                 DynamicOperatingEnvelopeResponse,
                 seed=707,
                 response_type=ResponseType.EVENT_RECEIVED,
-                created_time=datetime(2024, 11, 9, tzinfo=timezone.utc),
+                created_time=datetime(2024, 11, 9, tzinfo=UTC),
                 site=site1,
                 dynamic_operating_envelope_id_snapshot=der_control_1.dynamic_operating_envelope_id,
             )
@@ -2630,7 +2630,7 @@ async def test_check_response_contents_all(
                 ArchiveDynamicOperatingEnvelope,
                 seed=idx * 1001,
                 site_id=site1.site_id,
-                deleted_time=datetime(2022, 11, 14, tzinfo=timezone.utc),
+                deleted_time=datetime(2022, 11, 14, tzinfo=UTC),
                 site_control_group_id=site_control_group.site_control_group_id,
                 calculation_log_id=None,
                 dynamic_operating_envelope_id=control_id,
@@ -2683,7 +2683,7 @@ async def test_check_response_contents_any(pg_base_config):
                 DynamicOperatingEnvelopeResponse,
                 seed=505,
                 response_type=ResponseType.EVENT_CANCELLED,
-                created_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
+                created_time=datetime(2024, 11, 10, tzinfo=UTC),
                 site=site1,
                 dynamic_operating_envelope_id_snapshot=der_control_1.dynamic_operating_envelope_id,
             )
@@ -2694,7 +2694,7 @@ async def test_check_response_contents_any(pg_base_config):
                 DynamicOperatingEnvelopeResponse,
                 seed=606,
                 response_type=ResponseType.EVENT_COMPLETED,
-                created_time=datetime(2024, 11, 11, tzinfo=timezone.utc),
+                created_time=datetime(2024, 11, 11, tzinfo=UTC),
                 site=site1,
                 dynamic_operating_envelope_id_snapshot=der_control_1.dynamic_operating_envelope_id,
             )
@@ -2705,7 +2705,7 @@ async def test_check_response_contents_any(pg_base_config):
                 DynamicOperatingEnvelopeResponse,
                 seed=707,
                 response_type=ResponseType.EVENT_RECEIVED,
-                created_time=datetime(2024, 11, 9, tzinfo=timezone.utc),
+                created_time=datetime(2024, 11, 9, tzinfo=UTC),
                 site=site1,
                 dynamic_operating_envelope_id_snapshot=der_control_1.dynamic_operating_envelope_id,
             )
@@ -2815,7 +2815,7 @@ async def test_check_response_contents_tag_DERC1(pg_base_config):
                 DynamicOperatingEnvelopeResponse,
                 seed=505,
                 response_type=ResponseType.EVENT_RECEIVED,
-                created_time=datetime(2024, 11, 9, tzinfo=timezone.utc),
+                created_time=datetime(2024, 11, 9, tzinfo=UTC),
                 site=site1,
                 dynamic_operating_envelope_id_snapshot=100,
             )
@@ -2826,7 +2826,7 @@ async def test_check_response_contents_tag_DERC1(pg_base_config):
                 DynamicOperatingEnvelopeResponse,
                 seed=606,
                 response_type=ResponseType.EVENT_COMPLETED,
-                created_time=datetime(2024, 11, 11, tzinfo=timezone.utc),
+                created_time=datetime(2024, 11, 11, tzinfo=UTC),
                 site=site1,
                 dynamic_operating_envelope_id_snapshot=100,
             )
@@ -2838,7 +2838,7 @@ async def test_check_response_contents_tag_DERC1(pg_base_config):
                 DynamicOperatingEnvelopeResponse,
                 seed=707,
                 response_type=ResponseType.EVENT_CANCELLED,
-                created_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
+                created_time=datetime(2024, 11, 10, tzinfo=UTC),
                 site=site1,
                 dynamic_operating_envelope_id_snapshot=200,
             )
@@ -3521,7 +3521,7 @@ async def test_do_check_readings_for_duration(pg_base_config, srt_ids: list[int]
     ],
 )
 def test_check_all_polls_at_correct_time_path_matching(request_path: str, expected: bool):
-    base_time = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    base_time = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
     poll_interval = 60
 
     active_test_procedure = generate_class_instance(
@@ -3556,7 +3556,7 @@ def test_check_all_polls_at_correct_time_path_matching(request_path: str, expect
     ],
 )
 def test_check_all_polls_at_correct_time_poll_count(offsets_seconds: list[int], description_contains: str):
-    base_time = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    base_time = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
     poll_interval = 60
 
     active_test_procedure = generate_class_instance(
@@ -3586,7 +3586,7 @@ def test_check_all_polls_at_correct_time_poll_count(offsets_seconds: list[int], 
 
 def test_check_all_polls_at_correct_time_filters_by_request_type():
     """Only requests matching request_type_str are counted - other methods are ignored."""
-    base_time = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    base_time = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
     poll_interval = 60
 
     active_test_procedure = generate_class_instance(
@@ -3624,7 +3624,7 @@ def test_check_all_polls_at_correct_time_filters_by_request_type():
 )
 def test_check_all_polls_at_correct_time_request_type_variants(request_type_str: str, request_method: http.HTTPMethod):
     """Each supported request_type_str correctly matches the corresponding HTTP method."""
-    base_time = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    base_time = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
     poll_interval = 60
 
     active_test_procedure = generate_class_instance(
@@ -3657,7 +3657,7 @@ def test_check_all_polls_at_correct_time_wildcard_checks_each_path_independently
     Two MUPs (/mup/2 and /mup/3) both posting at 60s are each valid individually even
     though their combined count per window would exceed the maximum.
     """
-    base_time = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    base_time = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
     poll_interval = 60
 
     active_test_procedure = generate_class_instance(
@@ -3688,7 +3688,7 @@ def test_check_all_polls_at_correct_time_wildcard_checks_each_path_independently
 
 def test_check_all_polls_at_correct_time_wildcard_fails_when_one_path_misses_polls():
     """With a wildcard endpoint, a single path missing polls causes an overall failure."""
-    base_time = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    base_time = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
     poll_interval = 60
 
     active_test_procedure = generate_class_instance(
@@ -3744,7 +3744,7 @@ def test_check_all_polls_at_correct_time_wildcard_fails_when_one_path_misses_pol
 def test_check_all_polls_at_correct_time_missing_params(params: dict, description_contains: str):
     active_test_procedure = generate_class_instance(
         ActiveTestProcedure,
-        started_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        started_at=datetime(2024, 1, 1, tzinfo=UTC),
         step_status={},
         finished_zip_path=None,
     )

--- a/tests/unit/app/test_check.py
+++ b/tests/unit/app/test_check.py
@@ -122,14 +122,14 @@ def test_CHECK_TYPE_TO_HANDLER_in_sync():
 
     # Make sure we don't have any extra definitions not found in cactus-test-definitions
     for check_type in CHECK_TYPE_TO_HANDLER.keys():
-        assert (
-            check_type in CHECK_PARAMETER_SCHEMA
-        ), f"The check type {check_type} isn't defined in the test definitions (has it been removed/renamed)"
+        assert check_type in CHECK_PARAMETER_SCHEMA, (
+            f"The check type {check_type} isn't defined in the test definitions (has it been removed/renamed)"
+        )
 
     supported_checks = dict(((k, v) for k, v in CHECK_TYPE_TO_HANDLER.items() if v is not None))
-    assert len(set(supported_checks.values())) == len(
-        supported_checks
-    ), "At least 1 check type have listed the same check handler. This is likely a bug"
+    assert len(set(supported_checks.values())) == len(supported_checks), (
+        "At least 1 check type have listed the same check handler. This is likely a bug"
+    )
 
 
 def generate_active_test_procedure_steps(active_steps: list[str], all_steps: list[str]) -> ActiveTestProcedure:
@@ -1497,7 +1497,6 @@ async def test_do_check_readings_for_types(
     ]
 
     async with generate_async_session(pg_base_config) as session:
-
         result = await do_check_readings_for_types(session, faked_srts, minimum_count)
         assert_check_result(result, expected)
 
@@ -1595,7 +1594,6 @@ async def test_do_check_single_level(
     ]
 
     async with generate_async_session(pg_base_config) as session:
-
         result = await do_check_single_level(session, faked_srts, min_level, max_level)
         assert_check_result(result, expected)
 
@@ -2509,7 +2507,6 @@ async def test_check_response_contents_latest(pg_base_config):
     active_test_procedure = generate_class_instance(ActiveTestProcedure, step_status={}, finished_zip_path=None)
     # Fill up the DB with responses
     async with generate_async_session(pg_base_config) as session:
-
         site_control_group = generate_class_instance(SiteControlGroup, seed=101)
         session.add(site_control_group)
 
@@ -2611,7 +2608,6 @@ async def test_check_response_contents_all(
     active_test_procedure = generate_class_instance(ActiveTestProcedure, step_status={}, finished_zip_path=None)
     # Fill up the DB with responses
     async with generate_async_session(pg_base_config) as session:
-
         site_control_group = generate_class_instance(SiteControlGroup, seed=101)
         session.add(site_control_group)
 
@@ -2667,7 +2663,6 @@ async def test_check_response_contents_any(pg_base_config):
     active_test_procedure = generate_class_instance(ActiveTestProcedure, step_status={}, finished_zip_path=None)
     # Fill up the DB with responses
     async with generate_async_session(pg_base_config) as session:
-
         site_control_group = generate_class_instance(SiteControlGroup, seed=101)
         session.add(site_control_group)
 
@@ -2786,7 +2781,6 @@ async def test_check_response_contents_tag_DERC1(pg_base_config):
 
     # Fill up the DB with responses
     async with generate_async_session(pg_base_config) as session:
-
         site_control_group = generate_class_instance(SiteControlGroup, seed=101)
         session.add(site_control_group)
 
@@ -3273,9 +3267,9 @@ async def test_check_der_settings_contents_error_messages_meaningful(
         result = await check_der_settings_contents(session, resolved_params)
         assert_check_result(result, expected)
         assert result.description is not None
-        assert (
-            re.search(msg_regex, result.description) is not None
-        ), f"'{msg_regex}' not found in '{result.description}'"
+        assert re.search(msg_regex, result.description) is not None, (
+            f"'{msg_regex}' not found in '{result.description}'"
+        )
 
 
 @pytest.mark.parametrize(
@@ -3460,9 +3454,9 @@ async def test_check_der_capability_contents_error_messages_meaningful(
         result = await check_der_capability_contents(session, resolved_params)
         assert_check_result(result, expected)
         assert result.description is not None
-        assert (
-            re.search(msg_regex, result.description) is not None
-        ), f"'{msg_regex}' not found in '{result.description}'"
+        assert re.search(msg_regex, result.description) is not None, (
+            f"'{msg_regex}' not found in '{result.description}'"
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/app/test_check.py
+++ b/tests/unit/app/test_check.py
@@ -1724,7 +1724,7 @@ async def test_do_check_reading_levels_for_types(
         case (False, False):
             assert_check_result(result, True)
         case _:
-            assert False, "Unhandled test case found"
+            raise AssertionError("Unhandled test case found")
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/app/test_check.py
+++ b/tests/unit/app/test_check.py
@@ -2141,9 +2141,9 @@ async def test_check_readings_unique(mock_do_check_site_readings_and_params: moc
 
     # Assert
     assert mock_do_check_site_readings_and_params.call_count == len(reading_checks)
-    assert len(set(a.args[2:] for a in mock_do_check_site_readings_and_params.call_args_list)) == len(
-        reading_checks
-    ), "Each call to do_check_site_readings_and_params should have unique params (ignoring session/resolved_params)"
+    assert len(set(a.args[2:] for a in mock_do_check_site_readings_and_params.call_args_list)) == len(reading_checks), (
+        "Each call to do_check_site_readings_and_params should have unique params (ignoring session/resolved_params)"
+    )
 
     assert_mock_session(mock_session)
 

--- a/tests/unit/app/test_envoy.py
+++ b/tests/unit/app/test_envoy.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from http import HTTPStatus
 from unittest.mock import AsyncMock, MagicMock
 
@@ -126,8 +126,8 @@ async def test_delete_site_controls_in_range(mock_session_with_json_response):
     client = EnvoyAdminClient("http://localhost", EnvoyAdminClientAuthParams("user", "pass"))
     client._session = mock_session
 
-    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
-    end = datetime(2024, 1, 2, tzinfo=timezone.utc)
+    start = datetime(2024, 1, 1, tzinfo=UTC)
+    end = datetime(2024, 1, 2, tzinfo=UTC)
 
     status = await client.delete_site_controls_in_range(group_id=1, period_start=start, period_end=end)
 

--- a/tests/unit/app/test_envoy_common.py
+++ b/tests/unit/app/test_envoy_common.py
@@ -553,8 +553,9 @@ async def test_get_site_control_group_defaults_with_archive(pg_base_config):
             len(
                 list(
                     filter(
-                        lambda sc: isinstance(sc, ArchiveSiteControlGroupDefault)
-                        and sc.ramp_rate_percent_per_second == 3,
+                        lambda sc: (
+                            isinstance(sc, ArchiveSiteControlGroupDefault) and sc.ramp_rate_percent_per_second == 3
+                        ),
                         result,
                     )
                 )
@@ -565,8 +566,9 @@ async def test_get_site_control_group_defaults_with_archive(pg_base_config):
             len(
                 list(
                     filter(
-                        lambda sc: isinstance(sc, ArchiveSiteControlGroupDefault)
-                        and sc.ramp_rate_percent_per_second == 4,
+                        lambda sc: (
+                            isinstance(sc, ArchiveSiteControlGroupDefault) and sc.ramp_rate_percent_per_second == 4
+                        ),
                         result,
                     )
                 )
@@ -648,8 +650,9 @@ async def test_get_site_controls_active_archived(pg_base_config):
             len(
                 list(
                     filter(
-                        lambda sc: isinstance(sc, DynamicOperatingEnvelope)
-                        and sc.import_limit_active_watts == Decimal("1.11"),
+                        lambda sc: (
+                            isinstance(sc, DynamicOperatingEnvelope) and sc.import_limit_active_watts == Decimal("1.11")
+                        ),
                         result,
                     )
                 )
@@ -660,8 +663,9 @@ async def test_get_site_controls_active_archived(pg_base_config):
             len(
                 list(
                     filter(
-                        lambda sc: isinstance(sc, DynamicOperatingEnvelope)
-                        and sc.import_limit_active_watts == Decimal("2.22"),
+                        lambda sc: (
+                            isinstance(sc, DynamicOperatingEnvelope) and sc.import_limit_active_watts == Decimal("2.22")
+                        ),
                         result,
                     )
                 )
@@ -672,8 +676,9 @@ async def test_get_site_controls_active_archived(pg_base_config):
             len(
                 list(
                     filter(
-                        lambda sc: isinstance(sc, DynamicOperatingEnvelope)
-                        and sc.import_limit_active_watts == Decimal("3.33"),
+                        lambda sc: (
+                            isinstance(sc, DynamicOperatingEnvelope) and sc.import_limit_active_watts == Decimal("3.33")
+                        ),
                         result,
                     )
                 )
@@ -684,8 +689,10 @@ async def test_get_site_controls_active_archived(pg_base_config):
             len(
                 list(
                     filter(
-                        lambda sc: isinstance(sc, ArchiveDynamicOperatingEnvelope)
-                        and sc.import_limit_active_watts == Decimal("4.44"),
+                        lambda sc: (
+                            isinstance(sc, ArchiveDynamicOperatingEnvelope)
+                            and sc.import_limit_active_watts == Decimal("4.44")
+                        ),
                         result,
                     )
                 )
@@ -696,8 +703,10 @@ async def test_get_site_controls_active_archived(pg_base_config):
             len(
                 list(
                     filter(
-                        lambda sc: isinstance(sc, ArchiveDynamicOperatingEnvelope)
-                        and sc.import_limit_active_watts == Decimal("5.55"),
+                        lambda sc: (
+                            isinstance(sc, ArchiveDynamicOperatingEnvelope)
+                            and sc.import_limit_active_watts == Decimal("5.55")
+                        ),
                         result,
                     )
                 )

--- a/tests/unit/app/test_evaluator.py
+++ b/tests/unit/app/test_evaluator.py
@@ -6,6 +6,7 @@ from typing import Any
 import pytest
 from assertical.fake.generator import generate_class_instance
 from assertical.fake.sqlalchemy import assert_mock_session, create_mock_session
+from cactus_test_definitions.errors import UnresolvableVariableError
 from cactus_test_definitions.variable_expressions import (
     Constant,
     Expression,
@@ -13,7 +14,6 @@ from cactus_test_definitions.variable_expressions import (
     NamedVariableType,
     OperationType,
 )
-from cactus_test_definitions.errors import UnresolvableVariableError
 from envoy.server.model.site import Site, SiteDER, SiteDERSetting
 from freezegun import freeze_time
 

--- a/tests/unit/app/test_evaluator.py
+++ b/tests/unit/app/test_evaluator.py
@@ -1,5 +1,5 @@
 import unittest.mock as mock
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from typing import Any
 
@@ -79,16 +79,16 @@ DATABASE_SET_MAX_W = 2020.0
         (Constant(timedelta(hours=1.23)), timedelta(hours=1.23)),
         (
             NamedVariable(NamedVariableType.NOW),
-            datetime(2024, 9, 10, 1, 2, 3, tzinfo=timezone.utc),
+            datetime(2024, 9, 10, 1, 2, 3, tzinfo=UTC),
         ),  # Time frozen to this
         (NamedVariable(NamedVariableType.DERSETTING_SET_MAX_W), DATABASE_SET_MAX_W),  # DB fixed with this
         (
             Expression(OperationType.ADD, NamedVariable(NamedVariableType.NOW), Constant(timedelta(hours=1))),
-            datetime(2024, 9, 10, 2, 2, 3, tzinfo=timezone.utc),
+            datetime(2024, 9, 10, 2, 2, 3, tzinfo=UTC),
         ),
         (
             Expression(OperationType.SUBTRACT, NamedVariable(NamedVariableType.NOW), Constant(timedelta(hours=1))),
-            datetime(2024, 9, 10, 0, 2, 3, tzinfo=timezone.utc),
+            datetime(2024, 9, 10, 0, 2, 3, tzinfo=UTC),
         ),
         (
             Expression(OperationType.MULTIPLY, NamedVariable(NamedVariableType.DERSETTING_SET_MAX_W), Constant(0.5)),

--- a/tests/unit/app/test_event.py
+++ b/tests/unit/app/test_event.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from http import HTTPMethod
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -147,62 +147,62 @@ def test_generate_client_request_trigger_query_start(query: dict, expected_query
     "trigger, listener, expected",
     [
         (
-            event.EventTrigger(event.EventTriggerType.TIME, datetime(2022, 11, 10, tzinfo=timezone.utc), False, None),
+            event.EventTrigger(event.EventTriggerType.TIME, datetime(2022, 11, 10, tzinfo=UTC), False, None),
             Listener(
                 step="step",
                 event=Event(type="GET-request-received", parameters={"endpoint": evaluator.ResolvedParam("/dcap")}),
                 actions=[],
-                enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
+                enabled_time=datetime(2024, 11, 10, tzinfo=UTC),
             ),
             False,  # Wrong type of event
         ),
         (
-            event.EventTrigger(event.EventTriggerType.TIME, datetime(2022, 11, 10, tzinfo=timezone.utc), False, None),
+            event.EventTrigger(event.EventTriggerType.TIME, datetime(2022, 11, 10, tzinfo=UTC), False, None),
             Listener(
                 step="step",
                 event=Event(type="unsupported-event-type", parameters={}),
                 actions=[],
-                enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
+                enabled_time=datetime(2024, 11, 10, tzinfo=UTC),
             ),
             False,  # Unrecognized event type
         ),
         (
-            event.EventTrigger(event.EventTriggerType.TIME, datetime(2022, 11, 10, tzinfo=timezone.utc), False, None),
+            event.EventTrigger(event.EventTriggerType.TIME, datetime(2022, 11, 10, tzinfo=UTC), False, None),
             Listener(
                 step="step",
                 event=Event(type="wait", parameters={"duration_seconds": evaluator.ResolvedParam(300)}),
                 actions=[],
-                enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
+                enabled_time=datetime(2024, 11, 10, tzinfo=UTC),
             ),
             False,  # This was enabled after the event trigger (negative time)
         ),
         (
             event.EventTrigger(
-                event.EventTriggerType.TIME, datetime(2024, 11, 10, 5, 5, 4, tzinfo=timezone.utc), False, None
+                event.EventTriggerType.TIME, datetime(2024, 11, 10, 5, 5, 4, tzinfo=UTC), False, None
             ),
             Listener(
                 step="step",
                 event=Event(type="wait", parameters={"duration_seconds": evaluator.ResolvedParam(300)}),
                 actions=[],
-                enabled_time=datetime(2024, 11, 10, 5, 5, 5, tzinfo=timezone.utc),
+                enabled_time=datetime(2024, 11, 10, 5, 5, 5, tzinfo=UTC),
             ),
             False,  # This was enabled shortly after the event trigger (negative time)
         ),
         (
             event.EventTrigger(
-                event.EventTriggerType.TIME, datetime(2024, 11, 10, 5, 30, 0, tzinfo=timezone.utc), False, None
+                event.EventTriggerType.TIME, datetime(2024, 11, 10, 5, 30, 0, tzinfo=UTC), False, None
             ),
             Listener(
                 step="step",
                 event=Event(type="wait", parameters={"duration_seconds": evaluator.ResolvedParam(300)}),
                 actions=[],
-                enabled_time=datetime(2024, 11, 10, 5, 24, 0, tzinfo=timezone.utc),
+                enabled_time=datetime(2024, 11, 10, 5, 24, 0, tzinfo=UTC),
             ),
             True,
         ),
         (
             event.EventTrigger(
-                event.EventTriggerType.TIME, datetime(2024, 11, 10, 5, 30, 0, tzinfo=timezone.utc), False, None
+                event.EventTriggerType.TIME, datetime(2024, 11, 10, 5, 30, 0, tzinfo=UTC), False, None
             ),
             Listener(
                 step="step",
@@ -214,20 +214,20 @@ def test_generate_client_request_trigger_query_start(query: dict, expected_query
         ),
         (
             event.EventTrigger(
-                event.EventTriggerType.TIME, datetime(2024, 11, 10, 5, 30, 0, tzinfo=timezone.utc), False, None
+                event.EventTriggerType.TIME, datetime(2024, 11, 10, 5, 30, 0, tzinfo=UTC), False, None
             ),
             Listener(
                 step="step",
                 event=Event(type="wait", parameters={"duration_seconds": evaluator.ResolvedParam(300)}),
                 actions=[],
-                enabled_time=datetime(2024, 11, 10, 5, 26, 0, tzinfo=timezone.utc),
+                enabled_time=datetime(2024, 11, 10, 5, 26, 0, tzinfo=UTC),
             ),
             False,  # Not enough time elapsed
         ),
         (
             event.EventTrigger(
                 event.EventTriggerType.CLIENT_REQUEST_BEFORE,
-                datetime(2022, 11, 10, tzinfo=timezone.utc),
+                datetime(2022, 11, 10, tzinfo=UTC),
                 False,
                 event.ClientRequestDetails(HTTPMethod.GET, "/foo/bar"),
             ),
@@ -235,14 +235,14 @@ def test_generate_client_request_trigger_query_start(query: dict, expected_query
                 step="step",
                 event=Event(type="GET-request-received", parameters={"endpoint": evaluator.ResolvedParam("/foo/bar")}),
                 actions=[],
-                enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
+                enabled_time=datetime(2024, 11, 10, tzinfo=UTC),
             ),
             True,
         ),
         (
             event.EventTrigger(
                 event.EventTriggerType.CLIENT_REQUEST_BEFORE,
-                datetime(2022, 11, 10, tzinfo=timezone.utc),
+                datetime(2022, 11, 10, tzinfo=UTC),
                 False,
                 event.ClientRequestDetails(HTTPMethod.POST, "/foo/bar"),
             ),
@@ -250,14 +250,14 @@ def test_generate_client_request_trigger_query_start(query: dict, expected_query
                 step="step",
                 event=Event(type="POST-request-received", parameters={"endpoint": evaluator.ResolvedParam("/foo/bar")}),
                 actions=[],
-                enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
+                enabled_time=datetime(2024, 11, 10, tzinfo=UTC),
             ),
             True,
         ),
         (
             event.EventTrigger(
                 event.EventTriggerType.CLIENT_REQUEST_BEFORE,
-                datetime(2022, 11, 10, tzinfo=timezone.utc),
+                datetime(2022, 11, 10, tzinfo=UTC),
                 False,
                 event.ClientRequestDetails(HTTPMethod.PUT, "/foo/bar"),
             ),
@@ -265,14 +265,14 @@ def test_generate_client_request_trigger_query_start(query: dict, expected_query
                 step="step",
                 event=Event(type="PUT-request-received", parameters={"endpoint": evaluator.ResolvedParam("/foo/bar")}),
                 actions=[],
-                enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
+                enabled_time=datetime(2024, 11, 10, tzinfo=UTC),
             ),
             True,
         ),
         (
             event.EventTrigger(
                 event.EventTriggerType.CLIENT_REQUEST_BEFORE,
-                datetime(2022, 11, 10, tzinfo=timezone.utc),
+                datetime(2022, 11, 10, tzinfo=UTC),
                 False,
                 event.ClientRequestDetails(HTTPMethod.GET, "/foo/bar"),
             ),
@@ -286,14 +286,14 @@ def test_generate_client_request_trigger_query_start(query: dict, expected_query
                     },
                 ),
                 actions=[],
-                enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
+                enabled_time=datetime(2024, 11, 10, tzinfo=UTC),
             ),
             True,
         ),
         (
             event.EventTrigger(
                 event.EventTriggerType.CLIENT_REQUEST_AFTER,
-                datetime(2022, 11, 10, tzinfo=timezone.utc),
+                datetime(2022, 11, 10, tzinfo=UTC),
                 False,
                 event.ClientRequestDetails(HTTPMethod.GET, "/foo/bar"),
             ),
@@ -307,14 +307,14 @@ def test_generate_client_request_trigger_query_start(query: dict, expected_query
                     },
                 ),
                 actions=[],
-                enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
+                enabled_time=datetime(2024, 11, 10, tzinfo=UTC),
             ),
             True,
         ),
         (
             event.EventTrigger(
                 event.EventTriggerType.CLIENT_REQUEST_BEFORE,
-                datetime(2022, 11, 10, tzinfo=timezone.utc),
+                datetime(2022, 11, 10, tzinfo=UTC),
                 False,
                 event.ClientRequestDetails(HTTPMethod.GET, "/my/endppoint/1"),
             ),
@@ -324,14 +324,14 @@ def test_generate_client_request_trigger_query_start(query: dict, expected_query
                     type="GET-request-received", parameters={"endpoint": evaluator.ResolvedParam("/my/endppoint/1")}
                 ),
                 actions=[],
-                enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
+                enabled_time=datetime(2024, 11, 10, tzinfo=UTC),
             ),
             True,
         ),
         (
             event.EventTrigger(
                 event.EventTriggerType.CLIENT_REQUEST_AFTER,
-                datetime(2022, 11, 10, tzinfo=timezone.utc),
+                datetime(2022, 11, 10, tzinfo=UTC),
                 False,
                 event.ClientRequestDetails(HTTPMethod.GET, "/foo/bar"),
             ),
@@ -339,14 +339,14 @@ def test_generate_client_request_trigger_query_start(query: dict, expected_query
                 step="step",
                 event=Event(type="GET-request-received", parameters={"endpoint": evaluator.ResolvedParam("/foo/bar")}),
                 actions=[],
-                enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
+                enabled_time=datetime(2024, 11, 10, tzinfo=UTC),
             ),
             False,  # Without serve_request_first: True - Only BEFORE events will fire
         ),
         (
             event.EventTrigger(
                 event.EventTriggerType.CLIENT_REQUEST_BEFORE,
-                datetime(2022, 11, 10, tzinfo=timezone.utc),
+                datetime(2022, 11, 10, tzinfo=UTC),
                 False,
                 event.ClientRequestDetails(HTTPMethod.GET, "/foo"),
             ),
@@ -354,14 +354,14 @@ def test_generate_client_request_trigger_query_start(query: dict, expected_query
                 step="step",
                 event=Event(type="GET-request-received", parameters={"endpoint": evaluator.ResolvedParam("/foo/bar")}),
                 actions=[],
-                enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
+                enabled_time=datetime(2024, 11, 10, tzinfo=UTC),
             ),
             False,  # Wrong endpoint
         ),
         (
             event.EventTrigger(
                 event.EventTriggerType.CLIENT_REQUEST_BEFORE,
-                datetime(2022, 11, 10, tzinfo=timezone.utc),
+                datetime(2022, 11, 10, tzinfo=UTC),
                 False,
                 event.ClientRequestDetails(HTTPMethod.GET, "/foo/bar"),
             ),
@@ -369,14 +369,14 @@ def test_generate_client_request_trigger_query_start(query: dict, expected_query
                 step="step",
                 event=Event(type="GET-request-received", parameters={"endpoint": evaluator.ResolvedParam("/foo")}),
                 actions=[],
-                enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
+                enabled_time=datetime(2024, 11, 10, tzinfo=UTC),
             ),
             False,  # Wrong endpoint
         ),
         (
             event.EventTrigger(
                 event.EventTriggerType.CLIENT_REQUEST_BEFORE,
-                datetime(2022, 11, 10, tzinfo=timezone.utc),
+                datetime(2022, 11, 10, tzinfo=UTC),
                 False,
                 event.ClientRequestDetails(HTTPMethod.POST, "/foo/bar"),
             ),
@@ -384,14 +384,14 @@ def test_generate_client_request_trigger_query_start(query: dict, expected_query
                 step="step",
                 event=Event(type="GET-request-received", parameters={"endpoint": evaluator.ResolvedParam("/foo/bar")}),
                 actions=[],
-                enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
+                enabled_time=datetime(2024, 11, 10, tzinfo=UTC),
             ),
             False,  # Wrong method
         ),
         (
             event.EventTrigger(
                 event.EventTriggerType.CLIENT_REQUEST_BEFORE,
-                datetime(2022, 11, 10, tzinfo=timezone.utc),
+                datetime(2022, 11, 10, tzinfo=UTC),
                 False,
                 event.ClientRequestDetails(HTTPMethod.GET, "/foo/bar"),
             ),
@@ -406,7 +406,7 @@ def test_generate_client_request_trigger_query_start(query: dict, expected_query
         (
             event.EventTrigger(
                 event.EventTriggerType.CLIENT_REQUEST_BEFORE,
-                datetime(2022, 11, 10, tzinfo=timezone.utc),
+                datetime(2022, 11, 10, tzinfo=UTC),
                 False,
                 event.ClientRequestDetails(HTTPMethod.GET, "/foo/123/bar/456"),
             ),
@@ -416,49 +416,49 @@ def test_generate_client_request_trigger_query_start(query: dict, expected_query
                     type="GET-request-received", parameters={"endpoint": evaluator.ResolvedParam("/foo/*/bar/*")}
                 ),
                 actions=[],
-                enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
+                enabled_time=datetime(2024, 11, 10, tzinfo=UTC),
             ),
             True,
         ),
         (
             event.EventTrigger(
-                event.EventTriggerType.PROCEED, datetime(2022, 11, 10, tzinfo=timezone.utc), False, None
+                event.EventTriggerType.PROCEED, datetime(2022, 11, 10, tzinfo=UTC), False, None
             ),
             Listener(
                 step="step",
                 event=Event(type="GET-request-received", parameters={"endpoint": evaluator.ResolvedParam("/dcap")}),
                 actions=[],
-                enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
+                enabled_time=datetime(2024, 11, 10, tzinfo=UTC),
             ),
             False,  # Wrong type of event
         ),
         (
             event.EventTrigger(
-                event.EventTriggerType.PROCEED, datetime(2022, 11, 10, tzinfo=timezone.utc), False, None
+                event.EventTriggerType.PROCEED, datetime(2022, 11, 10, tzinfo=UTC), False, None
             ),
             Listener(
                 step="step",
                 event=Event(type="unsupported-event-type", parameters={}),
                 actions=[],
-                enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
+                enabled_time=datetime(2024, 11, 10, tzinfo=UTC),
             ),
             False,  # Unrecognized event type
         ),
         (
             event.EventTrigger(
-                event.EventTriggerType.PROCEED, datetime(2024, 11, 10, 5, 30, 0, tzinfo=timezone.utc), False, None
+                event.EventTriggerType.PROCEED, datetime(2024, 11, 10, 5, 30, 0, tzinfo=UTC), False, None
             ),
             Listener(
                 step="step",
                 event=Event(type="proceed", parameters={}),
                 actions=[],
-                enabled_time=datetime(2024, 11, 10, 5, 24, 0, tzinfo=timezone.utc),
+                enabled_time=datetime(2024, 11, 10, 5, 24, 0, tzinfo=UTC),
             ),
             True,
         ),
         (
             event.EventTrigger(
-                event.EventTriggerType.PROCEED, datetime(2024, 11, 10, 5, 30, 0, tzinfo=timezone.utc), False, None
+                event.EventTriggerType.PROCEED, datetime(2024, 11, 10, 5, 30, 0, tzinfo=UTC), False, None
             ),
             Listener(
                 step="step",
@@ -470,56 +470,56 @@ def test_generate_client_request_trigger_query_start(query: dict, expected_query
         ),
         (
             event.EventTrigger(
-                event.EventTriggerType.TIME, datetime(2024, 11, 10, 5, 30, 0, tzinfo=timezone.utc), False, None
+                event.EventTriggerType.TIME, datetime(2024, 11, 10, 5, 30, 0, tzinfo=UTC), False, None
             ),
             Listener(
                 step="step",
                 event=Event(type="proceed", parameters={"timeout_seconds": evaluator.ResolvedParam(300)}),
                 actions=[],
-                enabled_time=datetime(2024, 11, 10, 5, 24, 0, tzinfo=timezone.utc),
+                enabled_time=datetime(2024, 11, 10, 5, 24, 0, tzinfo=UTC),
             ),
             True,  # proceed with timeout_seconds fires via TIME trigger once elapsed
         ),
         (
             event.EventTrigger(
-                event.EventTriggerType.TIME, datetime(2024, 11, 10, 5, 30, 0, tzinfo=timezone.utc), False, None
+                event.EventTriggerType.TIME, datetime(2024, 11, 10, 5, 30, 0, tzinfo=UTC), False, None
             ),
             Listener(
                 step="step",
                 event=Event(type="proceed", parameters={"timeout_seconds": evaluator.ResolvedParam(300)}),
                 actions=[],
-                enabled_time=datetime(2024, 11, 10, 5, 26, 0, tzinfo=timezone.utc),
+                enabled_time=datetime(2024, 11, 10, 5, 26, 0, tzinfo=UTC),
             ),
             False,  # Not enough time elapsed
         ),
         (
             event.EventTrigger(
-                event.EventTriggerType.TIME, datetime(2024, 11, 10, 5, 30, 0, tzinfo=timezone.utc), False, None
+                event.EventTriggerType.TIME, datetime(2024, 11, 10, 5, 30, 0, tzinfo=UTC), False, None
             ),
             Listener(
                 step="step",
                 event=Event(type="proceed", parameters={}),
                 actions=[],
-                enabled_time=datetime(2024, 11, 10, 5, 24, 0, tzinfo=timezone.utc),
+                enabled_time=datetime(2024, 11, 10, 5, 24, 0, tzinfo=UTC),
             ),
             False,  # proceed without timeout_seconds does NOT fire via TIME trigger
         ),
         (
             event.EventTrigger(
-                event.EventTriggerType.PROCEED, datetime(2024, 11, 10, 5, 30, 0, tzinfo=timezone.utc), False, None
+                event.EventTriggerType.PROCEED, datetime(2024, 11, 10, 5, 30, 0, tzinfo=UTC), False, None
             ),
             Listener(
                 step="step",
                 event=Event(type="proceed", parameters={"timeout_seconds": evaluator.ResolvedParam(300)}),
                 actions=[],
-                enabled_time=datetime(2024, 11, 10, 5, 26, 0, tzinfo=timezone.utc),
+                enabled_time=datetime(2024, 11, 10, 5, 26, 0, tzinfo=UTC),
             ),
             True,  # Manual PROCEED still fires even when timeout_seconds is set but not yet elapsed
         ),
         (
             event.EventTrigger(
                 event.EventTriggerType.CLIENT_REQUEST_BEFORE,
-                datetime(2022, 11, 10, tzinfo=timezone.utc),
+                datetime(2022, 11, 10, tzinfo=UTC),
                 False,
                 event.ClientRequestDetails(HTTPMethod.GET, "/edev", query_start=0),
             ),
@@ -527,14 +527,14 @@ def test_generate_client_request_trigger_query_start(query: dict, expected_query
                 step="step",
                 event=Event(type="GET-request-received", parameters={"endpoint": evaluator.ResolvedParam("/edev")}),
                 actions=[],
-                enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
+                enabled_time=datetime(2024, 11, 10, tzinfo=UTC),
             ),
             True,  # s=0 (first page) should trigger
         ),
         (
             event.EventTrigger(
                 event.EventTriggerType.CLIENT_REQUEST_BEFORE,
-                datetime(2022, 11, 10, tzinfo=timezone.utc),
+                datetime(2022, 11, 10, tzinfo=UTC),
                 False,
                 event.ClientRequestDetails(HTTPMethod.GET, "/edev", query_start=1),
             ),
@@ -542,14 +542,14 @@ def test_generate_client_request_trigger_query_start(query: dict, expected_query
                 step="step",
                 event=Event(type="GET-request-received", parameters={"endpoint": evaluator.ResolvedParam("/edev")}),
                 actions=[],
-                enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
+                enabled_time=datetime(2024, 11, 10, tzinfo=UTC),
             ),
             False,  # s=1 (second page) should NOT trigger
         ),
         (
             event.EventTrigger(
                 event.EventTriggerType.CLIENT_REQUEST_BEFORE,
-                datetime(2022, 11, 10, tzinfo=timezone.utc),
+                datetime(2022, 11, 10, tzinfo=UTC),
                 False,
                 event.ClientRequestDetails(HTTPMethod.GET, "/edev", query_start=5),
             ),
@@ -557,14 +557,14 @@ def test_generate_client_request_trigger_query_start(query: dict, expected_query
                 step="step",
                 event=Event(type="GET-request-received", parameters={"endpoint": evaluator.ResolvedParam("/edev")}),
                 actions=[],
-                enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
+                enabled_time=datetime(2024, 11, 10, tzinfo=UTC),
             ),
             False,  # s=5 (paginated) should NOT trigger
         ),
         (
             event.EventTrigger(
                 event.EventTriggerType.CLIENT_REQUEST_BEFORE,
-                datetime(2022, 11, 10, tzinfo=timezone.utc),
+                datetime(2022, 11, 10, tzinfo=UTC),
                 False,
                 event.ClientRequestDetails(HTTPMethod.GET, "/edev", query_start=None),
             ),
@@ -572,7 +572,7 @@ def test_generate_client_request_trigger_query_start(query: dict, expected_query
                 step="step",
                 event=Event(type="GET-request-received", parameters={"endpoint": evaluator.ResolvedParam("/edev")}),
                 actions=[],
-                enabled_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
+                enabled_time=datetime(2024, 11, 10, tzinfo=UTC),
             ),
             True,  # No s param should trigger (same as first page)
         ),

--- a/tests/unit/app/test_event.py
+++ b/tests/unit/app/test_event.py
@@ -177,9 +177,7 @@ def test_generate_client_request_trigger_query_start(query: dict, expected_query
             False,  # This was enabled after the event trigger (negative time)
         ),
         (
-            event.EventTrigger(
-                event.EventTriggerType.TIME, datetime(2024, 11, 10, 5, 5, 4, tzinfo=UTC), False, None
-            ),
+            event.EventTrigger(event.EventTriggerType.TIME, datetime(2024, 11, 10, 5, 5, 4, tzinfo=UTC), False, None),
             Listener(
                 step="step",
                 event=Event(type="wait", parameters={"duration_seconds": evaluator.ResolvedParam(300)}),
@@ -189,9 +187,7 @@ def test_generate_client_request_trigger_query_start(query: dict, expected_query
             False,  # This was enabled shortly after the event trigger (negative time)
         ),
         (
-            event.EventTrigger(
-                event.EventTriggerType.TIME, datetime(2024, 11, 10, 5, 30, 0, tzinfo=UTC), False, None
-            ),
+            event.EventTrigger(event.EventTriggerType.TIME, datetime(2024, 11, 10, 5, 30, 0, tzinfo=UTC), False, None),
             Listener(
                 step="step",
                 event=Event(type="wait", parameters={"duration_seconds": evaluator.ResolvedParam(300)}),
@@ -201,9 +197,7 @@ def test_generate_client_request_trigger_query_start(query: dict, expected_query
             True,
         ),
         (
-            event.EventTrigger(
-                event.EventTriggerType.TIME, datetime(2024, 11, 10, 5, 30, 0, tzinfo=UTC), False, None
-            ),
+            event.EventTrigger(event.EventTriggerType.TIME, datetime(2024, 11, 10, 5, 30, 0, tzinfo=UTC), False, None),
             Listener(
                 step="step",
                 event=Event(type="wait", parameters={"duration_seconds": evaluator.ResolvedParam(300)}),
@@ -213,9 +207,7 @@ def test_generate_client_request_trigger_query_start(query: dict, expected_query
             False,  # This listener is NOT enabled
         ),
         (
-            event.EventTrigger(
-                event.EventTriggerType.TIME, datetime(2024, 11, 10, 5, 30, 0, tzinfo=UTC), False, None
-            ),
+            event.EventTrigger(event.EventTriggerType.TIME, datetime(2024, 11, 10, 5, 30, 0, tzinfo=UTC), False, None),
             Listener(
                 step="step",
                 event=Event(type="wait", parameters={"duration_seconds": evaluator.ResolvedParam(300)}),
@@ -421,9 +413,7 @@ def test_generate_client_request_trigger_query_start(query: dict, expected_query
             True,
         ),
         (
-            event.EventTrigger(
-                event.EventTriggerType.PROCEED, datetime(2022, 11, 10, tzinfo=UTC), False, None
-            ),
+            event.EventTrigger(event.EventTriggerType.PROCEED, datetime(2022, 11, 10, tzinfo=UTC), False, None),
             Listener(
                 step="step",
                 event=Event(type="GET-request-received", parameters={"endpoint": evaluator.ResolvedParam("/dcap")}),
@@ -433,9 +423,7 @@ def test_generate_client_request_trigger_query_start(query: dict, expected_query
             False,  # Wrong type of event
         ),
         (
-            event.EventTrigger(
-                event.EventTriggerType.PROCEED, datetime(2022, 11, 10, tzinfo=UTC), False, None
-            ),
+            event.EventTrigger(event.EventTriggerType.PROCEED, datetime(2022, 11, 10, tzinfo=UTC), False, None),
             Listener(
                 step="step",
                 event=Event(type="unsupported-event-type", parameters={}),
@@ -469,9 +457,7 @@ def test_generate_client_request_trigger_query_start(query: dict, expected_query
             False,  # This listener is NOT enabled
         ),
         (
-            event.EventTrigger(
-                event.EventTriggerType.TIME, datetime(2024, 11, 10, 5, 30, 0, tzinfo=UTC), False, None
-            ),
+            event.EventTrigger(event.EventTriggerType.TIME, datetime(2024, 11, 10, 5, 30, 0, tzinfo=UTC), False, None),
             Listener(
                 step="step",
                 event=Event(type="proceed", parameters={"timeout_seconds": evaluator.ResolvedParam(300)}),
@@ -481,9 +467,7 @@ def test_generate_client_request_trigger_query_start(query: dict, expected_query
             True,  # proceed with timeout_seconds fires via TIME trigger once elapsed
         ),
         (
-            event.EventTrigger(
-                event.EventTriggerType.TIME, datetime(2024, 11, 10, 5, 30, 0, tzinfo=UTC), False, None
-            ),
+            event.EventTrigger(event.EventTriggerType.TIME, datetime(2024, 11, 10, 5, 30, 0, tzinfo=UTC), False, None),
             Listener(
                 step="step",
                 event=Event(type="proceed", parameters={"timeout_seconds": evaluator.ResolvedParam(300)}),
@@ -493,9 +477,7 @@ def test_generate_client_request_trigger_query_start(query: dict, expected_query
             False,  # Not enough time elapsed
         ),
         (
-            event.EventTrigger(
-                event.EventTriggerType.TIME, datetime(2024, 11, 10, 5, 30, 0, tzinfo=UTC), False, None
-            ),
+            event.EventTrigger(event.EventTriggerType.TIME, datetime(2024, 11, 10, 5, 30, 0, tzinfo=UTC), False, None),
             Listener(
                 step="step",
                 event=Event(type="proceed", parameters={}),

--- a/tests/unit/app/test_event.py
+++ b/tests/unit/app/test_event.py
@@ -677,8 +677,8 @@ async def test_handle_event_trigger_normal_operation(
     )
 
     # we want a unique "checks" reference for each event listener so we can look it up later
-    for idx, l in enumerate(listeners):
-        l.event = generate_class_instance(Event, seed=idx, checks=MagicMock(), parameters={})
+    for idx, listener in enumerate(listeners):
+        listener.event = generate_class_instance(Event, seed=idx, checks=MagicMock(), parameters={})
 
     def find_index(to_find, items) -> int | None:
         for idx, i in enumerate(items):

--- a/tests/unit/app/test_finalize.py
+++ b/tests/unit/app/test_finalize.py
@@ -11,6 +11,7 @@ import pytest
 from assertical.asserts.generator import assert_class_instance_equality
 from assertical.asserts.time import assert_nowish
 from assertical.fake.generator import generate_class_instance
+from cactus_schema.runner.schema import RequestEntry
 
 from cactus_runner.app import finalize
 from cactus_runner.app.timeline import Timeline
@@ -21,7 +22,6 @@ from cactus_runner.models import (
     RunnerState,
     Site,
 )
-from cactus_schema.runner.schema import RequestEntry
 
 DT_NOW = datetime.now(timezone.utc)
 

--- a/tests/unit/app/test_finalize.py
+++ b/tests/unit/app/test_finalize.py
@@ -3,7 +3,7 @@ import random
 import string
 import tempfile
 import zipfile
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 
 import pandas as pd
@@ -23,7 +23,7 @@ from cactus_runner.models import (
     Site,
 )
 
-DT_NOW = datetime.now(timezone.utc)
+DT_NOW = datetime.now(UTC)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/app/test_handler.py
+++ b/tests/unit/app/test_handler.py
@@ -1,6 +1,6 @@
 import asyncio
 import http
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, call
 
@@ -45,7 +45,7 @@ from tests.integration.certificate2 import (
 
 
 def mocked_ProxyResult(status: int) -> ProxyResult:
-    return ProxyResult("", "", bytes(), None, {}, Response(status=status))
+    return ProxyResult("", "", b"", None, {}, Response(status=status))
 
 
 def run_request(test_procedure_id: TestProcedureId, use_device_cert: bool = False) -> RunRequest:
@@ -756,7 +756,7 @@ async def test_proxied_request_handler_replaces_existing_proxied_request_interac
 
     # Seed a prior PROXIED_REQUEST so the replace branch is exercised
     prior_interaction = ClientInteraction(
-        interaction_type=ClientInteractionType.PROXIED_REQUEST, timestamp=datetime(2020, 1, 1, tzinfo=timezone.utc)
+        interaction_type=ClientInteractionType.PROXIED_REQUEST, timestamp=datetime(2020, 1, 1, tzinfo=UTC)
     )
     request.app[APPKEY_RUNNER_STATE].client_interactions.append(prior_interaction)
     interactions_before = len(request.app[APPKEY_RUNNER_STATE].client_interactions)

--- a/tests/unit/app/test_models.py
+++ b/tests/unit/app/test_models.py
@@ -80,7 +80,6 @@ def test_reporting_data_versions():
 
     # Perform checks on each version of a reporting data class
     for ReportingDataClass in reporting_data_classes:
-
         # All reporting classes must be subclasses of ReportingData_Base in order to receive the version attribute
         assert issubclass(ReportingDataClass, ReportingData_Base)
 

--- a/tests/unit/app/test_precondition.py
+++ b/tests/unit/app/test_precondition.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from assertical.asserts.type import assert_list_type
@@ -120,7 +120,7 @@ async def test_register_aggregator(pg_empty_config, subscription_domain: str | N
         certs = (await session.execute(select(Certificate))).scalars().all()
         assert len(certs) == 1, "Only a single cert should be injected"
         assert certs[0].lfdi == lfdi
-        assert certs[0].expiry > (datetime.now(timezone.utc) + timedelta(hours=4)), "Why is the expiry so short?"
+        assert certs[0].expiry > (datetime.now(UTC) + timedelta(hours=4)), "Why is the expiry so short?"
 
         cert_assignments = (await session.execute(select(AggregatorCertificateAssignment))).scalars().all()
         assert len(cert_assignments) == 1, "Single cert assigned to a single aggregator"

--- a/tests/unit/app/test_readings.py
+++ b/tests/unit/app/test_readings.py
@@ -220,7 +220,7 @@ def test_scale_readings(power_of_ten_multiplier, values, expected_scaled_values)
         expected_scaled_values = [Decimal(i) for i in expected_scaled_values]
         assert "scaled_value" in df
         TOLERANCE = 1e-5
-        for v1, v2 in zip(df["scaled_value"].tolist(), expected_scaled_values):
+        for v1, v2 in zip(df["scaled_value"].tolist(), expected_scaled_values, strict=True):
             assert abs(v1 - v2) < TOLERANCE
 
 

--- a/tests/unit/app/test_requests_archive.py
+++ b/tests/unit/app/test_requests_archive.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from http import HTTPMethod, HTTPStatus
 
 import pytest
@@ -45,7 +45,7 @@ def entry():
         path="/dcap",
         method=HTTPMethod.POST,
         status=HTTPStatus.OK,
-        timestamp=datetime.now(timezone.utc),
+        timestamp=datetime.now(UTC),
         step_name="ALL-01-001",
         body_xml_errors=[],
         request_id=0,
@@ -115,7 +115,7 @@ def test_write_request_response_files_creates_directory_if_missing():
         path="/test",
         method=HTTPMethod.GET,
         status=HTTPStatus.OK,
-        timestamp=datetime.now(timezone.utc),
+        timestamp=datetime.now(UTC),
         step_name="TEST-001",
         body_xml_errors=[],
         request_id=0,

--- a/tests/unit/app/test_schema_validator.py
+++ b/tests/unit/app/test_schema_validator.py
@@ -113,7 +113,7 @@ def test_validate_proxy_request_schema_schema_invalid(xml: str):
 
 def test_validate_proxy_request_schema_empty_body():
     """Tests that an empty body returns no errors"""
-    result = validate_proxy_request_schema(make_proxy_result(bytes()))
+    result = validate_proxy_request_schema(make_proxy_result(b""))
     assert_list_type(str, result, count=0)
 
 

--- a/tests/unit/app/test_status.py
+++ b/tests/unit/app/test_status.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from unittest.mock import Mock
 
 import pytest
@@ -23,7 +23,7 @@ from cactus_runner.app.timeline import Timeline, TimelineDataStream, duration_to
 from cactus_runner.models import ActiveTestProcedure, CheckResult, StepInfo
 
 PENDING_STEP = StepInfo()
-RESOLVED_STEP = StepInfo(started_at=datetime.now(tz=timezone.utc), completed_at=datetime.now(tz=timezone.utc))
+RESOLVED_STEP = StepInfo(started_at=datetime.now(tz=UTC), completed_at=datetime.now(tz=UTC))
 
 
 @pytest.mark.parametrize(
@@ -42,7 +42,7 @@ def test_get_runner_status_summary(step_status, expected):
     assert status.get_runner_status_summary(step_status=step_status) == expected
 
 
-BASIS = datetime(2023, 5, 7, tzinfo=timezone.utc)
+BASIS = datetime(2023, 5, 7, tzinfo=UTC)
 
 
 @pytest.mark.parametrize(
@@ -77,7 +77,7 @@ async def test_get_active_runner_status(mocker, resolve_max_w_result, timeline_s
 
     expected_test_name = "TEST_NAME"
     expected_step_status = {
-        "step_name": StepEventStatus(started_at=datetime.now(tz=timezone.utc), completed_at=None, event_status=None)
+        "step_name": StepEventStatus(started_at=datetime.now(tz=UTC), completed_at=None, event_status=None)
     }
     expected_status_summary = "0/1 steps complete."
     expected_csip_aus_version = CSIPAusVersion.RELEASE_1_2
@@ -93,7 +93,7 @@ async def test_get_active_runner_status(mocker, resolve_max_w_result, timeline_s
     active_test_procedure = generate_class_instance(
         ActiveTestProcedure,
         name=expected_test_name,
-        step_status={"step_name": StepInfo(started_at=datetime.now(tz=timezone.utc))},
+        step_status={"step_name": StepInfo(started_at=datetime.now(tz=UTC))},
         csip_aus_version=expected_csip_aus_version,
         definition=mock_definition,
         listeners=[],
@@ -346,8 +346,8 @@ def test_get_runner_status(example_client_interaction: ClientInteraction):
 async def test_get_timeline_data_streams(mocker, interval_seconds, data_streams, expected_data_streams):
     """Tests whether converting to the status timeline model raises any issues"""
     mock_session = create_mock_session()
-    start = datetime(2024, 11, 5, tzinfo=timezone.utc)
-    end = datetime(2024, 11, 6, tzinfo=timezone.utc)
+    start = datetime(2024, 11, 5, tzinfo=UTC)
+    end = datetime(2024, 11, 6, tzinfo=UTC)
 
     mock_generate_timeline = mocker.patch("cactus_runner.app.status.generate_timeline")
     mock_generate_timeline.return_value = generate_class_instance(Timeline, data_streams=data_streams)

--- a/tests/unit/app/test_status.py
+++ b/tests/unit/app/test_status.py
@@ -15,13 +15,12 @@ from cactus_schema.runner import (
 )
 from cactus_test_definitions import CSIPAusVersion
 from cactus_test_definitions.client import Check
-from freezegun import freeze_time
-
 from envoy.server.model.site import Site, SiteDER, SiteDERRating, SiteDERSetting, SiteDERStatus
+from freezegun import freeze_time
 
 from cactus_runner.app import status
 from cactus_runner.app.timeline import Timeline, TimelineDataStream, duration_to_label
-from cactus_runner.models import CheckResult, ActiveTestProcedure, StepInfo
+from cactus_runner.models import ActiveTestProcedure, CheckResult, StepInfo
 
 PENDING_STEP = StepInfo()
 RESOLVED_STEP = StepInfo(started_at=datetime.now(tz=timezone.utc), completed_at=datetime.now(tz=timezone.utc))

--- a/tests/unit/app/test_timeline.py
+++ b/tests/unit/app/test_timeline.py
@@ -1,5 +1,5 @@
 import unittest.mock as mock
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 
 import pytest
@@ -31,7 +31,7 @@ from cactus_runner.app.timeline import (
     reading_to_watts,
 )
 
-BASIS = datetime(2022, 1, 2, 3, 4, 5, 6, tzinfo=timezone.utc)  # Used as an arbitrary - non aligned datetime
+BASIS = datetime(2022, 1, 2, 3, 4, 5, 6, tzinfo=UTC)  # Used as an arbitrary - non aligned datetime
 
 
 @pytest.mark.parametrize(
@@ -111,21 +111,21 @@ def test_reading_to_watts(srts, reading, expected):
         ([generate_class_instance(SiteReading)], 0),
         (
             [
-                generate_class_instance(SiteReading, seed=101, changed_time=datetime(2022, 1, 1, tzinfo=timezone.utc)),
-                generate_class_instance(SiteReading, seed=202, changed_time=datetime(2021, 1, 1, tzinfo=timezone.utc)),
+                generate_class_instance(SiteReading, seed=101, changed_time=datetime(2022, 1, 1, tzinfo=UTC)),
+                generate_class_instance(SiteReading, seed=202, changed_time=datetime(2021, 1, 1, tzinfo=UTC)),
             ],
             0,
         ),  # changed_time is tiebreaker
         (
             [
                 generate_class_instance(
-                    DynamicOperatingEnvelope, seed=101, changed_time=datetime(2021, 1, 1, tzinfo=timezone.utc)
+                    DynamicOperatingEnvelope, seed=101, changed_time=datetime(2021, 1, 1, tzinfo=UTC)
                 ),
                 generate_class_instance(
-                    ArchiveDynamicOperatingEnvelope, seed=202, changed_time=datetime(2022, 1, 1, tzinfo=timezone.utc)
+                    ArchiveDynamicOperatingEnvelope, seed=202, changed_time=datetime(2022, 1, 1, tzinfo=UTC)
                 ),
                 generate_class_instance(
-                    ArchiveDynamicOperatingEnvelope, seed=303, changed_time=datetime(2023, 1, 1, tzinfo=timezone.utc)
+                    ArchiveDynamicOperatingEnvelope, seed=303, changed_time=datetime(2023, 1, 1, tzinfo=UTC)
                 ),
             ],
             0,
@@ -133,13 +133,13 @@ def test_reading_to_watts(srts, reading, expected):
         (
             [
                 generate_class_instance(
-                    ArchiveDynamicOperatingEnvelope, seed=101, changed_time=datetime(2021, 1, 1, tzinfo=timezone.utc)
+                    ArchiveDynamicOperatingEnvelope, seed=101, changed_time=datetime(2021, 1, 1, tzinfo=UTC)
                 ),
                 generate_class_instance(
-                    ArchiveDynamicOperatingEnvelope, seed=202, changed_time=datetime(2022, 1, 1, tzinfo=timezone.utc)
+                    ArchiveDynamicOperatingEnvelope, seed=202, changed_time=datetime(2022, 1, 1, tzinfo=UTC)
                 ),
                 generate_class_instance(
-                    ArchiveDynamicOperatingEnvelope, seed=303, changed_time=datetime(2023, 1, 1, tzinfo=timezone.utc)
+                    ArchiveDynamicOperatingEnvelope, seed=303, changed_time=datetime(2023, 1, 1, tzinfo=UTC)
                 ),
             ],
             2,
@@ -147,16 +147,16 @@ def test_reading_to_watts(srts, reading, expected):
         (
             [
                 generate_class_instance(
-                    ArchiveDynamicOperatingEnvelope, seed=101, changed_time=datetime(2021, 1, 1, tzinfo=timezone.utc)
+                    ArchiveDynamicOperatingEnvelope, seed=101, changed_time=datetime(2021, 1, 1, tzinfo=UTC)
                 ),
                 generate_class_instance(
-                    DynamicOperatingEnvelope, seed=202, changed_time=datetime(2022, 1, 1, tzinfo=timezone.utc)
+                    DynamicOperatingEnvelope, seed=202, changed_time=datetime(2022, 1, 1, tzinfo=UTC)
                 ),
                 generate_class_instance(
                     ArchiveDynamicOperatingEnvelope,
                     seed=303,
                     deleted_time=None,
-                    changed_time=datetime(2023, 1, 1, tzinfo=timezone.utc),
+                    changed_time=datetime(2023, 1, 1, tzinfo=UTC),
                 ),
             ],
             2,
@@ -167,21 +167,21 @@ def test_reading_to_watts(srts, reading, expected):
                     ArchiveDynamicOperatingEnvelope,
                     seed=101,
                     deleted_time=None,
-                    archive_time=datetime(2021, 1, 2, tzinfo=timezone.utc),  # highest archive time for tiebreak
+                    archive_time=datetime(2021, 1, 2, tzinfo=UTC),  # highest archive time for tiebreak
                 ),
                 generate_class_instance(
-                    DynamicOperatingEnvelope, seed=202, changed_time=datetime(2022, 1, 1, tzinfo=timezone.utc)
+                    DynamicOperatingEnvelope, seed=202, changed_time=datetime(2022, 1, 1, tzinfo=UTC)
                 ),
                 generate_class_instance(
                     ArchiveDynamicOperatingEnvelope,
                     seed=303,
                     deleted_time=None,
-                    archive_time=datetime(2021, 1, 1, tzinfo=timezone.utc),
+                    archive_time=datetime(2021, 1, 1, tzinfo=UTC),
                 ),
                 generate_class_instance(
                     ArchiveDynamicOperatingEnvelope,
                     seed=404,
-                    archive_time=datetime(2021, 1, 1, tzinfo=timezone.utc),
+                    archive_time=datetime(2021, 1, 1, tzinfo=UTC),
                 ),
             ],
             0,
@@ -220,7 +220,7 @@ def test_generate_offset_watt_values(interval_length_seconds, start, end, expect
             generate_class_instance(
                 ArchiveDynamicOperatingEnvelope,
                 seed=101,
-                changed_time=datetime(2021, 1, 1, tzinfo=timezone.utc),
+                changed_time=datetime(2021, 1, 1, tzinfo=UTC),
                 import_limit_active_watts=Decimal("1"),
                 export_limit_watts=Decimal("11"),
             ),
@@ -231,7 +231,7 @@ def test_generate_offset_watt_values(interval_length_seconds, start, end, expect
             generate_class_instance(
                 DynamicOperatingEnvelope,
                 seed=202,
-                changed_time=datetime(2021, 1, 1, tzinfo=timezone.utc),
+                changed_time=datetime(2021, 1, 1, tzinfo=UTC),
                 import_limit_active_watts=Decimal("2"),
                 export_limit_watts=Decimal("22"),
             ),
@@ -242,7 +242,7 @@ def test_generate_offset_watt_values(interval_length_seconds, start, end, expect
             generate_class_instance(
                 DynamicOperatingEnvelope,
                 seed=303,
-                changed_time=datetime(2020, 1, 1, tzinfo=timezone.utc),
+                changed_time=datetime(2020, 1, 1, tzinfo=UTC),
                 import_limit_active_watts=Decimal("3"),
                 export_limit_watts=Decimal("33"),
             ),
@@ -253,7 +253,7 @@ def test_generate_offset_watt_values(interval_length_seconds, start, end, expect
             generate_class_instance(
                 DynamicOperatingEnvelope,
                 seed=404,
-                changed_time=datetime(2021, 1, 1, 9, tzinfo=timezone.utc),
+                changed_time=datetime(2021, 1, 1, 9, tzinfo=UTC),
                 import_limit_active_watts=Decimal("4"),
                 export_limit_watts=Decimal("44"),
             ),
@@ -264,7 +264,7 @@ def test_generate_offset_watt_values(interval_length_seconds, start, end, expect
             generate_class_instance(
                 ArchiveDynamicOperatingEnvelope,
                 seed=505,
-                changed_time=datetime(2025, 1, 1, tzinfo=timezone.utc),
+                changed_time=datetime(2025, 1, 1, tzinfo=UTC),
                 import_limit_active_watts=Decimal("5"),
                 export_limit_watts=Decimal("55"),
             ),
@@ -275,7 +275,7 @@ def test_generate_offset_watt_values(interval_length_seconds, start, end, expect
             generate_class_instance(
                 ArchiveDynamicOperatingEnvelope,
                 seed=606,
-                changed_time=datetime(2020, 1, 1, tzinfo=timezone.utc),
+                changed_time=datetime(2020, 1, 1, tzinfo=UTC),
                 import_limit_active_watts=Decimal("6"),
                 export_limit_watts=Decimal("66"),
             ),
@@ -309,7 +309,7 @@ async def test_generate_readings_data_stream_empty_db(pg_empty_config):
     assert result.label == "foo"
     assert isinstance(result.offset_watt_values, list)
     assert len(result.offset_watt_values) == 10, "10 seconds of 1 second intervals"
-    assert all((v is None for v in result.offset_watt_values))
+    assert all(v is None for v in result.offset_watt_values)
 
 
 @mock.patch("cactus_runner.app.timeline.get_csip_aus_site_reading_types")
@@ -636,7 +636,7 @@ async def test_generate_control_data_streams(
 
     # Assert
     assert_list_type(TimelineDataStream, result, len(expected))
-    assert len(set((ds.label for ds in result))) == len(result), "Expecting unique labels"
+    assert len(set(ds.label for ds in result)) == len(result), "Expecting unique labels"
     actual = [ds.offset_watt_values for ds in result]
     assert expected == actual
 
@@ -728,7 +728,7 @@ async def test_generate_default_control_data_streams(
 
     # Assert
     assert_list_type(TimelineDataStream, result, len(expected))
-    assert len(set((ds.label for ds in result))) == len(expected), "Expecting unique labels"
+    assert len(set(ds.label for ds in result)) == len(expected), "Expecting unique labels"
     actual = [ds.offset_watt_values for ds in result]
     assert expected == actual
 

--- a/tests/unit/client/conftest.py
+++ b/tests/unit/client/conftest.py
@@ -11,9 +11,7 @@ from cactus_schema.runner import (
 )
 
 PENDING_STEP = StepEventStatus(started_at=None, completed_at=None, event_status=None)
-RESOLVED_STEP = StepEventStatus(
-    started_at=datetime.now(tz=UTC), completed_at=datetime.now(tz=UTC), event_status=None
-)
+RESOLVED_STEP = StepEventStatus(started_at=datetime.now(tz=UTC), completed_at=datetime.now(tz=UTC), event_status=None)
 
 
 @pytest.fixture

--- a/tests/unit/client/conftest.py
+++ b/tests/unit/client/conftest.py
@@ -1,5 +1,5 @@
 import http
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 from cactus_schema.runner import (
@@ -12,20 +12,20 @@ from cactus_schema.runner import (
 
 PENDING_STEP = StepEventStatus(started_at=None, completed_at=None, event_status=None)
 RESOLVED_STEP = StepEventStatus(
-    started_at=datetime.now(tz=timezone.utc), completed_at=datetime.now(tz=timezone.utc), event_status=None
+    started_at=datetime.now(tz=UTC), completed_at=datetime.now(tz=UTC), event_status=None
 )
 
 
 @pytest.fixture
 def runner_status_fixture():
     return RunnerStatus(
-        timestamp_status=datetime(2022, 4, 5, tzinfo=timezone.utc),
-        timestamp_initialise=datetime(2022, 4, 6, tzinfo=timezone.utc),
-        timestamp_start=datetime(2022, 4, 7, tzinfo=timezone.utc),
+        timestamp_status=datetime(2022, 4, 5, tzinfo=UTC),
+        timestamp_initialise=datetime(2022, 4, 6, tzinfo=UTC),
+        timestamp_start=datetime(2022, 4, 7, tzinfo=UTC),
         log_envoy="log for\nenvoy",
         status_summary="status summary here",
         last_client_interaction=ClientInteraction(
-            interaction_type=ClientInteractionType.PROXIED_REQUEST, timestamp=datetime.now(timezone.utc)
+            interaction_type=ClientInteractionType.PROXIED_REQUEST, timestamp=datetime.now(UTC)
         ),
         csip_aus_version="v1.2",
         test_procedure_name="ALL-01",
@@ -41,7 +41,7 @@ def runner_status_fixture():
                 path="/dcap",
                 method=http.HTTPMethod.GET,
                 status=http.HTTPStatus.OK,
-                timestamp=datetime.now(timezone.utc),
+                timestamp=datetime.now(UTC),
                 step_name="ALL-01-001",
                 body_xml_errors=[],
                 request_id=1,

--- a/tests/unit/client/test_client.py
+++ b/tests/unit/client/test_client.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from http import HTTPStatus
 from unittest.mock import MagicMock
 
@@ -19,7 +19,7 @@ from cactus_schema.runner import (
 )
 from cactus_test_definitions.client import TestProcedureId
 
-from cactus_runner.client import RunnerClient, RunnerClientException
+from cactus_runner.client import RunnerClient, RunnerClientError
 
 
 def make_run_request(run_id: str = "test-run-123") -> RunRequest:
@@ -44,7 +44,7 @@ async def test_initialise():
     expected_init_result = InitResponseBody(
         status="PLACEHOLDER-STATUS",
         test_procedure="ALL-01",
-        timestamp=datetime.now(timezone.utc),
+        timestamp=datetime.now(UTC),
         is_started=False,
     )
     run_request = make_run_request()
@@ -70,7 +70,7 @@ async def test_initialise_connectionerror():
     run_request = make_run_request()
 
     # Act/Assert
-    with pytest.raises(RunnerClientException, match="Unexpected failure while initialising test"):
+    with pytest.raises(RunnerClientError, match="Unexpected failure while initialising test"):
         _ = await RunnerClient.initialise(
             session=mock_session,
             run_request=run_request,
@@ -84,7 +84,7 @@ async def test_initialise_playlist():
     expected_init_result = InitResponseBody(
         status="PLACEHOLDER-STATUS",
         test_procedure="ALL-01",
-        timestamp=datetime.now(timezone.utc),
+        timestamp=datetime.now(UTC),
         is_started=True,
     )
     run_requests = [make_run_request("test-1"), make_run_request("test-2"), make_run_request("test-3")]
@@ -109,7 +109,7 @@ async def test_initialise_playlist():
 async def test_start():
     # Arrange
     expected_start_result = StartResponseBody(
-        status="PLACEHOLDER-STATUS", test_procedure="ALL-01", timestamp=datetime.now(timezone.utc)
+        status="PLACEHOLDER-STATUS", test_procedure="ALL-01", timestamp=datetime.now(UTC)
     )
     mock_session = MagicMock()
     mock_session.post.return_value.__aenter__.return_value.status = 200
@@ -134,7 +134,7 @@ async def test_start_precondition_failures():
     mock_session.post.return_value.__aenter__.return_value.text.return_value = expected_error_message
 
     # Act
-    with pytest.raises(RunnerClientException) as exc_info:
+    with pytest.raises(RunnerClientError) as exc_info:
         await RunnerClient.start(session=mock_session)
 
     # Assert
@@ -149,7 +149,7 @@ async def test_start_connectionerror():
     mock_session.post.side_effect = ConnectionTimeoutError
 
     # Act/Assert
-    with pytest.raises(RunnerClientException, match="Unexpected failure while starting test."):
+    with pytest.raises(RunnerClientError, match="Unexpected failure while starting test."):
         _ = await RunnerClient.start(session=mock_session)
 
 
@@ -158,7 +158,7 @@ async def test_finalize():
     # Arrange
     mock_session = MagicMock()
     mock_session.post.return_value.__aenter__.return_value.status = 200
-    mock_session.post.return_value.__aenter__.return_value.read.return_value = bytes()
+    mock_session.post.return_value.__aenter__.return_value.read.return_value = b""
 
     # Act
     finalize_result = await RunnerClient.finalize(session=mock_session)
@@ -176,7 +176,7 @@ async def test_finalize_connectionerror():
     mock_session.post.side_effect = ConnectionTimeoutError
 
     # Act/Assert
-    with pytest.raises(RunnerClientException, match="Unexpected failure while finalizing test procedure."):
+    with pytest.raises(RunnerClientError, match="Unexpected failure while finalizing test procedure."):
         _ = await RunnerClient.finalize(session=mock_session)
 
 
@@ -205,7 +205,7 @@ async def test_status_connectionerror():
     mock_session.get.side_effect = ConnectionTimeoutError
 
     # Act/Assert
-    with pytest.raises(RunnerClientException, match="Unexpected failure while requesting test procedure status."):
+    with pytest.raises(RunnerClientError, match="Unexpected failure while requesting test procedure status."):
         _ = await RunnerClient.status(session=mock_session)
 
 
@@ -234,7 +234,7 @@ async def test_last_interaction_connectionerror():
     mock_session.get.side_effect = ConnectionTimeoutError
 
     # Act/Assert
-    with pytest.raises(RunnerClientException, match="Unexpected failure while requesting test procedure status."):
+    with pytest.raises(RunnerClientError, match="Unexpected failure while requesting test procedure status."):
         _ = await RunnerClient.last_interaction(session=mock_session)
 
 
@@ -263,5 +263,5 @@ async def test_proceed_connectionerror():
     mock_session.get.side_effect = ConnectionTimeoutError
 
     # Act/Assert
-    with pytest.raises(RunnerClientException, match="Unexpected failure while sending proceed request to test runner."):
+    with pytest.raises(RunnerClientError, match="Unexpected failure while sending proceed request to test runner."):
         _ = await RunnerClient.proceed(session=mock_session)


### PR DESCRIPTION
Will copy paste these PR notes across the PR's and specifically flag anything truly odd if needed.

Replace black, isort, flake8, flake8-bugbear, bandit, and mccabe with ruff.

Key config choices:

Rules: E, W, F, I, S, C90, B, UP, ANN, N: equivalent to the old toolchain plus pyupgrade (UP) and type annotation enforcement (ANN), and N (naming conventions).
max-complexity = 10. Overly complex functions get # noqa: C901 rather than being refactored.
raise ... from err: enforced (B904). Where the original exception is already logged with exc_info=, I use from None to avoid a redundant chained traceback.
Some config suppressed in tests for simplicity.