### PR TITLE
PDF: Fix three-phase active power chart; add opModStorageTargetW timeline stream

### DIFF
--- a/src/cactus_runner/app/timeline.py
+++ b/src/cactus_runner/app/timeline.py
@@ -281,10 +281,15 @@ async def generate_control_data_streams(
                 lambda e: decimal_to_watts(cast(DynamicOperatingEnvelope, e).export_limit_watts, True),
                 lambda e: decimal_to_watts(cast(DynamicOperatingEnvelope, e).load_limit_active_watts, False),
                 lambda e: decimal_to_watts(cast(DynamicOperatingEnvelope, e).generation_limit_active_watts, True),
+                lambda e: decimal_to_watts(
+                    getattr(cast(DynamicOperatingEnvelope, e), "storage_target_active_watts", None), True
+                ),
             ],
         )
 
         # These indexes correspond 1-1 with the lambda's above
+        # opModStorageTargetW (index 4) is only present on v1.3+ envoy schemas; it is filtered out
+        # by generate_timeline when all values are None (i.e. on v1.2 schemas).
         all_data_streams.extend(
             [
                 TimelineDataStream(
@@ -308,6 +313,12 @@ async def generate_control_data_streams(
                 TimelineDataStream(
                     label=f"/derp/{site_control_group_id} opModGenLimW",
                     offset_watt_values=offset_watt_values[3],
+                    stepped=True,
+                    dashed=False,
+                ),
+                TimelineDataStream(
+                    label=f"/derp/{site_control_group_id} opModStorageTargetW",
+                    offset_watt_values=offset_watt_values[4],
                     stepped=True,
                     dashed=False,
                 ),
@@ -350,10 +361,15 @@ async def generate_default_control_data_streams(
             lambda e: decimal_to_watts(cast(SiteControlGroupDefault, e).export_limit_active_watts, True),
             lambda e: decimal_to_watts(cast(SiteControlGroupDefault, e).load_limit_active_watts, False),
             lambda e: decimal_to_watts(cast(SiteControlGroupDefault, e).generation_limit_active_watts, True),
+            lambda e: decimal_to_watts(
+                getattr(cast(SiteControlGroupDefault, e), "storage_target_active_watts", None), True
+            ),
         ],
     )
 
     # These indexes correspond 1-1 with the lambda's above
+    # Default opModStorageTargetW (index 4) is only present on v1.3+ envoy schemas; it is filtered out
+    # by generate_timeline when all values are None (i.e. on v1.2 schemas).
     return [
         TimelineDataStream(
             label="Default opModImpLimW",
@@ -376,6 +392,12 @@ async def generate_default_control_data_streams(
         TimelineDataStream(
             label="Default opModGenLimW",
             offset_watt_values=offset_watt_values[3],
+            stepped=True,
+            dashed=True,
+        ),
+        TimelineDataStream(
+            label="Default opModStorageTargetW",
+            offset_watt_values=offset_watt_values[4],
             stepped=True,
             dashed=True,
         ),

--- a/src/cactus_runner/app/timeline.py
+++ b/src/cactus_runner/app/timeline.py
@@ -216,7 +216,7 @@ async def generate_readings_data_stream(
         # Sum across all SRTs at each interval; None only when ALL phases have no reading
         offset_watt_values: list[int | None] = [
             None if all(v is None for v in phase_readings) else sum(v for v in phase_readings if v is not None)
-            for phase_readings in zip(*per_srt_values)
+            for phase_readings in zip(*per_srt_values, strict=False)
         ]
     else:
         # No SiteReadingTypes found — produce the correct count of None values via an empty tree

--- a/src/cactus_runner/app/timeline.py
+++ b/src/cactus_runner/app/timeline.py
@@ -191,8 +191,9 @@ async def generate_readings_data_stream(
         session, UomType.REAL_POWER_WATT, location, KindType.POWER, DataQualifierType.AVERAGE
     )
 
-    # Build the interval tree from all matched readings
-    tree = IntervalTree()
+    # Build one interval tree per SiteReadingType. Multi-phase setups report each phase as a separate SRT;
+    # mixing them into one tree causes highest_priority_entity to discard all but one phase per interval.
+    per_srt_values: list[list[int | None]] = []
     for srt in srts:
         # Dump all readings - we will refine in memory
         # (we could be fancy and try to interrogate records within the start/end range but that introduces a bit more
@@ -200,16 +201,28 @@ async def generate_readings_data_stream(
         readings = await get_site_readings(session, srt)
         # Filter out null/zero durations to prevent IntervalTree crashes
         # This is silently dropped here, but is reported as error/warning in the PDF report post-test
-        tree.update(
+        tree = IntervalTree(
             Interval(r.time_period_start, r.time_period_start + timedelta(seconds=r.time_period_seconds), r)
             for r in readings
             if r.time_period_seconds is not None and r.time_period_seconds > 0
         )
+        per_srt_values.append(
+            generate_offset_watt_values(
+                tree, start, end, interval_seconds, [lambda e, _srt=srt: reading_to_watts([_srt], e)]
+            )[0]
+        )
 
-    # Generate all the reading data
-    offset_watt_values = generate_offset_watt_values(
-        tree, start, end, interval_seconds, [lambda e: reading_to_watts(srts, e)]
-    )[0]
+    if per_srt_values:
+        # Sum across all SRTs at each interval; None only when ALL phases have no reading
+        offset_watt_values: list[int | None] = [
+            None if all(v is None for v in phase_readings) else sum(v for v in phase_readings if v is not None)
+            for phase_readings in zip(*per_srt_values)
+        ]
+    else:
+        # No SiteReadingTypes found — produce the correct count of None values via an empty tree
+        offset_watt_values = generate_offset_watt_values(
+            IntervalTree(), start, end, interval_seconds, [lambda e: None]
+        )[0]
 
     return TimelineDataStream(label=label, offset_watt_values=offset_watt_values, stepped=False, dashed=False)
 

--- a/src/cactus_runner/models.py
+++ b/src/cactus_runner/models.py
@@ -355,7 +355,7 @@ class SiteDERRating(JSONWizard):
             max_var_value=rating.max_var_value,
             max_var_multiplier=rating.max_var_multiplier,
             max_var_neg_value=rating.max_var_neg_value,
-            max_var_neg_multiplier=rating.max_var_neg_value,
+            max_var_neg_multiplier=rating.max_var_neg_multiplier,
             max_w_value=rating.max_w_value,
             max_w_multiplier=rating.max_w_multiplier,
             max_wh_value=rating.max_wh_value,

--- a/tests/unit/app/test_timeline.py
+++ b/tests/unit/app/test_timeline.py
@@ -468,12 +468,61 @@ async def test_generate_readings_data_stream_three_phase(
     mock_get_site_readings.side_effect = readings_for
 
     result = await generate_readings_data_stream(
-        mock_session, "Three Phase", ReadingLocation.SITE_READING, BASIS, BASIS + timedelta(seconds=10), interval_seconds
+        mock_session,
+        "Three Phase",
+        ReadingLocation.SITE_READING,
+        BASIS,
+        BASIS + timedelta(seconds=10),
+        interval_seconds,
     )
 
     assert isinstance(result, TimelineDataStream)
     assert len(result.offset_watt_values) == 2, "10 seconds of 5 second intervals"
     assert result.offset_watt_values == [600, None], "Phase A+B+C summed at interval 1; no readings at interval 2"
+
+    assert_mock_session(mock_session)
+    mock_get_csip_aus_site_reading_types.assert_called_once()
+    mock_get_site_readings.assert_has_calls(
+        [mock.call(mock_session, srt_a), mock.call(mock_session, srt_b), mock.call(mock_session, srt_c)],
+        any_order=True,
+    )
+
+
+@mock.patch("cactus_runner.app.timeline.get_csip_aus_site_reading_types")
+@mock.patch("cactus_runner.app.timeline.get_site_readings")
+@pytest.mark.asyncio
+async def test_generate_readings_data_stream_partial_phase(
+    mock_get_site_readings: mock.MagicMock, mock_get_csip_aus_site_reading_types: mock.MagicMock
+):
+    """When only one phase has a reading in an interval the result equals that phase's value.
+    None appears only when NO phase has a reading — not when just some are absent."""
+    interval_seconds = 5
+    mock_session = create_mock_session()
+    srt_a = generate_class_instance(SiteReadingType, seed=1, power_of_ten_multiplier=0, site_reading_type_id=1)
+    srt_b = generate_class_instance(SiteReadingType, seed=2, power_of_ten_multiplier=0, site_reading_type_id=2)
+    srt_c = generate_class_instance(SiteReadingType, seed=3, power_of_ten_multiplier=0, site_reading_type_id=3)
+    mock_get_csip_aus_site_reading_types.return_value = [srt_a, srt_b, srt_c]
+
+    # Only srt_b reports in interval 1; no phase reports in interval 2
+    readings_b = [
+        generate_class_instance(
+            SiteReading,
+            seed=10,
+            site_reading_type_id=srt_b.site_reading_type_id,
+            value=750,
+            time_period_start=BASIS,
+            time_period_seconds=5,
+        )
+    ]
+    mock_get_site_readings.side_effect = lambda _, srt: readings_b if srt is srt_b else []
+
+    result = await generate_readings_data_stream(
+        mock_session, "Partial", ReadingLocation.SITE_READING, BASIS, BASIS + timedelta(seconds=10), interval_seconds
+    )
+
+    assert isinstance(result, TimelineDataStream)
+    assert len(result.offset_watt_values) == 2
+    assert result.offset_watt_values == [750, None], "Interval 1: only phase B reported; interval 2: no phases"
 
     assert_mock_session(mock_session)
     mock_get_csip_aus_site_reading_types.assert_called_once()
@@ -535,7 +584,7 @@ def doe(
             BASIS,
             5,
             BASIS + timedelta(seconds=10),
-            [[1, None], [-2, None], [3, None], [-4, None]],
+            [[1, None], [-2, None], [3, None], [-4, None], [None, None]],
         ),
         (
             [
@@ -553,7 +602,7 @@ def doe(
             BASIS,
             5,
             BASIS + timedelta(seconds=10),
-            [[1, None], [-2, None], [3, None], [-4, None]],
+            [[1, None], [-2, None], [3, None], [-4, None], [None, None]],
         ),  # Control was active for only the first 5 seconds before being deleted
         (
             [
@@ -564,7 +613,7 @@ def doe(
             BASIS,
             5,
             BASIS + timedelta(seconds=10),
-            [[11, None], [None, -22], [33, None], [None, -44]],
+            [[11, None], [None, -22], [33, None], [None, -44], [None, None]],
         ),  # Multiple Controls, some out of range of the interval period - no overlaps - with None values in controls
         (
             [
@@ -585,7 +634,13 @@ def doe(
             BASIS,
             5,
             BASIS + timedelta(seconds=20),
-            [[21, 31, 41, 31], [-22, -32, -42, -32], [23, 33, 43, 33], [-24, -34, -44, -34]],
+            [
+                [21, 31, 41, 31],
+                [-22, -32, -42, -32],
+                [23, 33, 43, 33],
+                [-24, -34, -44, -34],
+                [None, None, None, None],
+            ],
         ),  # Multiple Controls with overlaps
         (
             [
@@ -603,15 +658,18 @@ def doe(
                 [21, 11],
                 [-22, -12],
                 [23, 13],
-                [-24, -14],  # SCG 1
+                [-24, -14],
+                [None, None],  # SCG 1
                 [None, 31],
                 [None, -32],
                 [None, 33],
-                [None, -34],  # SCG 2
+                [None, -34],
+                [None, None],  # SCG 2
                 [41, 41],
                 [-42, -42],
                 [43, 43],
-                [-44, -44],  # SCG 3
+                [-44, -44],
+                [None, None],  # SCG 3
             ],
         ),  # Multiple control groups - mix of overlapping
         (
@@ -652,7 +710,13 @@ def doe(
             BASIS,
             10,
             BASIS + timedelta(seconds=40),
-            [[21, 31, None, None], [-22, -32, None, None], [23, 33, None, None], [-24, -34, None, None]],
+            [
+                [21, 31, None, None],
+                [-22, -32, None, None],
+                [23, 33, None, None],
+                [-24, -34, None, None],
+                [None, None, None, None],
+            ],
         ),  # Long control that gets superseded by a short control that is cancelled partway through.
     ],
 )
@@ -665,11 +729,12 @@ async def test_generate_control_data_streams(
 
     expected has the form:
     [
-        # These 4 lists will be repeated for EACH distinct SiteControlGroup
+        # These 5 lists will be repeated for EACH distinct SiteControlGroup
         [opModImpLimW vals]
         [opModExpLimW vals]
         [opModLoadLimW vals]
         [opModGenLimW vals]
+        [opModStorageTargetW vals]  # all None when envoy schema lacks the column
     ]
     """
     # Arrange
@@ -729,7 +794,7 @@ def def_ctrl(
             BASIS - timedelta(seconds=5),
             5,
             BASIS + timedelta(seconds=10),
-            [[None, 1, 1], [None, -2, -2], [None, 3, 3], [None, -4, -4]],
+            [[None, 1, 1], [None, -2, -2], [None, 3, 3], [None, -4, -4], [None, None, None]],
         ),
         (
             [
@@ -756,7 +821,7 @@ def def_ctrl(
             BASIS,
             5,
             BASIS + timedelta(seconds=15),
-            [[None, 21, 11], [-32, None, -12], [None, 23, 13], [-34, None, -14]],
+            [[None, 21, 11], [-32, None, -12], [None, 23, 13], [-34, None, -14], [None, None, None]],
         ),
     ],
 )

--- a/tests/unit/app/test_timeline.py
+++ b/tests/unit/app/test_timeline.py
@@ -350,7 +350,7 @@ async def test_generate_readings_data_stream(
             value=333,
             time_period_start=BASIS,
             time_period_seconds=5,
-        ),  # This will be highest priority due to having the highest changed_time
+        ),
     ]
     mock_get_site_readings.side_effect = lambda _, srt: srt1_readings if srt is srt1 else srt2_readings
 
@@ -364,7 +364,7 @@ async def test_generate_readings_data_stream(
     assert result.label == "bar"
     assert isinstance(result.offset_watt_values, list)
     assert len(result.offset_watt_values) == 2, "10 seconds of 5 second intervals"
-    assert result.offset_watt_values == [3330, 22], "Values adjusted for pow10 in SiteReadingType"
+    assert result.offset_watt_values == [3341, 22], "Values summed across both SRTs, adjusted for pow10"
 
     assert_mock_session(mock_session)
     mock_get_csip_aus_site_reading_types.assert_called_once()
@@ -435,6 +435,52 @@ async def test_generate_readings_data_stream_filters_null_and_zero_durations(
     assert_mock_session(mock_session)
     mock_get_csip_aus_site_reading_types.assert_called_once()
     mock_get_site_readings.assert_called_once_with(mock_session, srt)
+
+
+@mock.patch("cactus_runner.app.timeline.get_csip_aus_site_reading_types")
+@mock.patch("cactus_runner.app.timeline.get_site_readings")
+@pytest.mark.asyncio
+async def test_generate_readings_data_stream_three_phase(
+    mock_get_site_readings: mock.MagicMock, mock_get_csip_aus_site_reading_types: mock.MagicMock
+):
+    """Three concurrent single-phase SRTs covering the same interval should be summed, not winner-takes-all."""
+    interval_seconds = 5
+    mock_session = create_mock_session()
+    srt_a = generate_class_instance(SiteReadingType, seed=1, power_of_ten_multiplier=0, site_reading_type_id=1)
+    srt_b = generate_class_instance(SiteReadingType, seed=2, power_of_ten_multiplier=0, site_reading_type_id=2)
+    srt_c = generate_class_instance(SiteReadingType, seed=3, power_of_ten_multiplier=0, site_reading_type_id=3)
+    mock_get_csip_aus_site_reading_types.return_value = [srt_a, srt_b, srt_c]
+
+    phase_values = {srt_a: 100, srt_b: 200, srt_c: 300}
+
+    def readings_for(_, srt):
+        return [
+            generate_class_instance(
+                SiteReading,
+                seed=phase_values[srt],
+                site_reading_type_id=srt.site_reading_type_id,
+                value=phase_values[srt],
+                time_period_start=BASIS,
+                time_period_seconds=5,
+            )
+        ]
+
+    mock_get_site_readings.side_effect = readings_for
+
+    result = await generate_readings_data_stream(
+        mock_session, "Three Phase", ReadingLocation.SITE_READING, BASIS, BASIS + timedelta(seconds=10), interval_seconds
+    )
+
+    assert isinstance(result, TimelineDataStream)
+    assert len(result.offset_watt_values) == 2, "10 seconds of 5 second intervals"
+    assert result.offset_watt_values == [600, None], "Phase A+B+C summed at interval 1; no readings at interval 2"
+
+    assert_mock_session(mock_session)
+    mock_get_csip_aus_site_reading_types.assert_called_once()
+    mock_get_site_readings.assert_has_calls(
+        [mock.call(mock_session, srt_a), mock.call(mock_session, srt_b), mock.call(mock_session, srt_c)],
+        any_order=True,
+    )
 
 
 def doe(


### PR DESCRIPTION
**Three-phase readings**: 
In multi-phase setups, highest_priority_entity previously discarded all but the phase with the latest changed_time. Now each SRT gets its own tree; values are resolved per-SRT then summed across phases at each interval. None appears only when every phase has no reading at that slot.

**NOTE!** Behaviour change: readings from different SRTs that coincide in time are now summed rather than winner-takes-all. This only affects multi-phase sites; single-phase behaviour is unchanged (within a single SRT, highest_priority_entity still resolves overlaps as before).

**opModStorageTargetW**: 
Adds a fifth TimelineDataStream for opModStorageTargetW in both generate_control_data_streams and generate_default_control_data_streams. Uses getattr(..., "storage_target_active_watts", None) for backwards compatibility with envoy schemas that predate v1.3: generate_timeline filters the stream out automatically when all values are None.

Bugfix from synergy: Incorrectly assigning PDF report max var neg mutliplier