### PR TITLE
Bugfix  crop envoy logs for long running tests (all25 ext is hanging)

### DIFF
--- a/src/cactus_runner/app/log.py
+++ b/src/cactus_runner/app/log.py
@@ -90,11 +90,22 @@ class NonErrorFilter(logging.Filter):
         return record.levelno <= logging.INFO
 
 
-def read_log_file(log_file_path: str) -> str:
-    """Reads all text at the specified file path. Returns the resulting data or an error string.
+def read_log_file(log_file_path: str, tail_bytes: int | None = None) -> str:
+    """Reads text from the specified file path. Returns the resulting data or an error string.
 
-    Significantly large log files will be truncated"""
+    If tail_bytes is set, reads that many bytes from the end of the file (most recent entries).
+    Otherwise reads from the start, capped at 4MB."""
     try:
+        if tail_bytes is not None:
+            with open(log_file_path, "rb") as file:
+                file.seek(0, 2)  # Seek to end
+                size = file.tell()
+                file.seek(max(0, size - tail_bytes))
+                raw = file.read()
+                # Drop the first (potentially partial) line when seeking mid-file
+                if size > tail_bytes:
+                    raw = raw[raw.find(b"\n") + 1 :]
+                return raw.decode("utf-8", errors="replace")
         with open(log_file_path) as file:
             return file.read(1024 * 1024 * 4)  # Limit to 4MB so we don't over fetch - should be more than enough
     except Exception as exc:

--- a/src/cactus_runner/app/status.py
+++ b/src/cactus_runner/app/status.py
@@ -343,7 +343,7 @@ async def get_active_runner_status(
         timestamp_initialise=active_test_procedure.initialised_at,
         timestamp_start=active_test_procedure.started_at,
         csip_aus_version=active_test_procedure.csip_aus_version.value,
-        log_envoy=read_log_file(LOG_FILE_ENVOY_SERVER),
+        log_envoy=read_log_file(LOG_FILE_ENVOY_SERVER, tail_bytes=64 * 1024),
         test_procedure_name=active_test_procedure.name,
         last_client_interaction=last_client_interaction,
         criteria=await get_criteria_summary(session, active_test_procedure),
@@ -365,5 +365,5 @@ def get_runner_status(last_client_interaction: ClientInteraction) -> RunnerStatu
         csip_aus_version="",
         status_summary="No test procedure running",
         last_client_interaction=last_client_interaction,
-        log_envoy=read_log_file(LOG_FILE_ENVOY_SERVER),
+        log_envoy=read_log_file(LOG_FILE_ENVOY_SERVER, tail_bytes=64 * 1024),
     )

--- a/tests/unit/app/test_log.py
+++ b/tests/unit/app/test_log.py
@@ -21,3 +21,44 @@ def test_read_log_file_dne(tmp_path_factory):
 
     result = read_log_file(log_file_path)
     assert isinstance(result, str)
+
+
+def test_read_log_file_tail_returns_recent_lines(tmp_path_factory):
+    """tail_bytes should return only the end of the file, dropping the partial first line"""
+    lines = [f"line{i}" for i in range(100)]
+    log_data = "\n".join(lines) + "\n"
+
+    log_file_path = tmp_path_factory.mktemp("log") / "test.log"
+    log_file_path.write_text(log_data)
+
+    # Request only enough bytes to cover the last ~10 lines
+    tail_bytes = sum(len(f"line{i}\n") for i in range(90, 100))
+    result = read_log_file(log_file_path, tail_bytes=tail_bytes)
+
+    assert isinstance(result, str)
+    # The most recent lines are present
+    for i in range(91, 100):  # line90 may be partial and dropped
+        assert f"line{i}" in result
+    # Early lines are not present
+    assert "line0" not in result
+    assert "line50" not in result
+
+
+def test_read_log_file_tail_larger_than_file(tmp_path_factory):
+    """When tail_bytes exceeds file size, the full content is returned"""
+    log_data = "line1\nline2\nline3\n"
+
+    log_file_path = tmp_path_factory.mktemp("log") / "test.log"
+    log_file_path.write_text(log_data)
+
+    result = read_log_file(log_file_path, tail_bytes=1024 * 1024)
+
+    assert result == log_data
+
+
+def test_read_log_file_tail_dne(tmp_path_factory):
+    """Ensure tail mode doesn't crash on missing file"""
+    log_file_path = tmp_path_factory.mktemp("log") / "test.log"
+
+    result = read_log_file(log_file_path, tail_bytes=64 * 1024)
+    assert isinstance(result, str)


### PR DESCRIPTION
Crop envoy logs tail. (previously long runs sending 1.5MB + to UI each poll).

Maybe a little clunky to have both head and tail read options but preserves other functionality. Happy to chat about cleaning this up. 