### PR TITLE
fix: missing storage extension parameters in report data

### DIFF
--- a/src/cactus_runner/models.py
+++ b/src/cactus_runner/models.py
@@ -34,6 +34,7 @@ from envoy_schema.server.schema.sep2.der import (
     NormalCategoryType,
     OperationalModeStatusType,
     StorageModeStatusType,
+    VPPControlType,
 )
 from envoy_schema.server.schema.sep2.types import (
     AccumulationBehaviourType,
@@ -332,6 +333,7 @@ class SiteDERRating(JSONWizard):
     v_nom_multiplier: int | None
     der_type: DERType
     doe_modes_supported: DOESupportedMode | None
+    vpp_modes_supported: VPPControlType | None
 
     @classmethod
     def from_site_der_rating(cls, rating: EnvoySiteDERRating | None) -> Self | None:
@@ -389,6 +391,7 @@ class SiteDERRating(JSONWizard):
             v_nom_multiplier=rating.v_nom_multiplier,
             der_type=rating.der_type,
             doe_modes_supported=rating.doe_modes_supported,
+            vpp_modes_supported=rating.vpp_modes_supported,
         )
 
 
@@ -445,6 +448,9 @@ class SiteDERSetting(JSONWizard):
     v_ref_ofs_value: int | None
     v_ref_ofs_multiplier: int | None
     doe_modes_enabled: DOESupportedMode | None
+    vpp_modes_enabled: VPPControlType | None
+    min_wh_value: int | None
+    min_wh_multiplier: int | None
 
     @classmethod
     def from_site_der_setting(cls, setting: EnvoySiteDERSetting | None) -> Self | None:
@@ -503,6 +509,9 @@ class SiteDERSetting(JSONWizard):
             v_ref_ofs_value=setting.v_ref_ofs_value,
             v_ref_ofs_multiplier=setting.v_ref_ofs_multiplier,
             doe_modes_enabled=setting.doe_modes_enabled,
+            vpp_modes_enabled=setting.vpp_modes_enabled,
+            min_wh_value=setting.min_wh_value,
+            min_wh_multiplier=setting.min_wh_multiplier,
         )
 
 

--- a/tests/data/xml/edev_agg.xml
+++ b/tests/data/xml/edev_agg.xml
@@ -1,0 +1,5 @@
+<EndDevice xmlns="urn:ieee:std:2030.5:ns">
+    <lFDI>854d10a201ca99e5e90d3c3e1f9bc1c300000666</lFDI>
+    <sFDI>35915311648</sFDI>
+    <changedTime>1759733047</changedTime>
+</EndDevice>

--- a/tests/data/xml/mup_agg.xml
+++ b/tests/data/xml/mup_agg.xml
@@ -1,0 +1,21 @@
+<MirrorUsagePoint xmlns="urn:ieee:std:2030.5:ns">
+	<mRID>0600006C</mRID>
+	<description>Max Watts</description>
+	<roleFlags>03</roleFlags>
+	<serviceCategoryKind>0</serviceCategoryKind>
+	<status>1</status>
+	<deviceLFDI>854d10a201ca99e5e90d3c3e1f9bc1c300000666</deviceLFDI>
+	<MirrorMeterReading>
+		<mRID>0700006C</mRID>
+		<ReadingType>
+			<accumulationBehaviour>9</accumulationBehaviour>
+			<commodity>1</commodity>
+			<dataQualifier>2</dataQualifier>
+			<flowDirection>1</flowDirection>
+            <intervalLength>300</intervalLength>
+			<powerOfTenMultiplier>3</powerOfTenMultiplier>
+			<uom>38</uom>
+			<kind>37</kind>
+		</ReadingType>
+	</MirrorMeterReading>
+</MirrorUsagePoint>

--- a/tests/integration/test_all_01_with_readings.py
+++ b/tests/integration/test_all_01_with_readings.py
@@ -38,8 +38,9 @@ async def test_all_01_with_readings(
 
     # Load XML data from files
     xml_data_dir = Path(__file__).parent.parent / "data" / "xml"
-    edev_xml = (xml_data_dir / "edev.xml").read_text().strip()
+    edev_xml = (xml_data_dir / "edev_agg.xml").read_text().strip()
     mup_xml = (xml_data_dir / "mup.xml").read_text().strip()
+    mup_agg_xml = (xml_data_dir / "mup_agg.xml").read_text().strip()
     mmr_xml = (xml_data_dir / "mmr.xml").read_text().strip()
 
     # SETUP: The real ALL_01 (from test_all_01.py)
@@ -73,8 +74,9 @@ async def test_all_01_with_readings(
         await assert_success_response(result)
 
     # Post Mirror Usage Point
+    mup_data = mup_agg_xml if certificate_type == "aggregator_certificate" else mup_xml
     result = await cactus_runner_client.post(
-        "/mup", data=mup_xml, headers={"ssl-client-cert": URI_ENCODED_CERT, "Content-Type": env.HEADER_MEDIA_ALL}
+        "/mup", data=mup_data, headers={"ssl-client-cert": URI_ENCODED_CERT, "Content-Type": env.HEADER_MEDIA_ALL}
     )
     location = result.headers.get("Location")
     assert location is not None

--- a/tests/integration/test_all_07.py
+++ b/tests/integration/test_all_07.py
@@ -50,7 +50,7 @@ async def test_all_07_full(cactus_runner_client: TestClient, run_request_generat
         "/edev",
         headers={"ssl-client-cert": URI_ENCODED_CERT, "Content-Type": env.HEADER_MEDIA_ALL},
         data=EndDeviceRequest(
-            lFDI="854d10a201ca99e5e90d3c3e1f9bc1c3bd075f3b", sFDI=357827241281, changedTime=1766110684
+            lFDI="854d10a201ca99e5e90d3c3e1f9bc1c300000666", sFDI=357827241281, changedTime=1766110684
         ).to_xml(skip_empty=True, exclude_none=True),
     )
     await assert_success_response(result)

--- a/tests/integration/test_concurrent_requests.py
+++ b/tests/integration/test_concurrent_requests.py
@@ -102,9 +102,9 @@ async def test_twenty_concurrent_gets_all_listeners_triggered(cactus_runner_clie
         headers={
             "ssl-client-cert": URI_ENCODED_CERT,
         },
-        data=EndDeviceRequest(lFDI=TEST_CERTIFICATE_LFDI, sFDI=357827241281, changedTime=1766110684).to_xml(
-            skip_empty=True, exclude_none=True
-        ),
+        data=EndDeviceRequest(
+            lFDI=f"{TEST_CERTIFICATE_LFDI[:32]}{666:08d}", sFDI=357827241281, changedTime=1766110684
+        ).to_xml(skip_empty=True, exclude_none=True),
     )
     assert result.status < 300
 


### PR DESCRIPTION
Also preempting the problems that may come up with updating envoy when aggregator lfdi clash checks may become a problem. These changes are more representative of the requests that would occur from an aggregator client.

Synergy reference
AB#232040