### PR TITLE
Check polls correct time fix

### DIFF
--- a/src/cactus_runner/app/check.py
+++ b/src/cactus_runner/app/check.py
@@ -1273,22 +1273,24 @@ def _check_poll_timing_for_path(
     poll_interval_seconds: int,
     test_started_at: datetime,
 ) -> CheckResult:
-    """Checks that requests in path_requests occur at the expected frequency using a window-based approach.
+    """Checks that requests in path_requests occur at the expected frequency.
 
-    For each window of 3x the poll interval, expects at least 2 requests and no more than min(expected*3, expected+3).
+    Per-window minimum: for each window of 3x the poll interval, expects at least 2 requests. This ensures
+    polls are distributed throughout the test rather than front- or back-loaded.
+
+    Global maximum: total polls must not exceed min(expected_total * 3, expected_total + 3), where expected_total
+    is based on actual test duration. This scales correctly — short tests get proportionally more slack, long tests
+    are held to a tight fixed buffer of +3 above expected.
     """
     sorted_requests = sorted(path_requests, key=lambda r: r.timestamp)
     last_request_time = sorted_requests[-1].timestamp
 
-    # Window of 3x poll interval: 2 interior polls always land in the window,
-    # 2 boundary polls may drift in/out with ±50% jitter, giving a range of 2 to min(expected*3, expected+3).
     window_seconds = poll_interval_seconds * 3
-    expected_polls_per_window = window_seconds // poll_interval_seconds
     min_polls_per_window = 2
-    max_polls_per_window = min(expected_polls_per_window * 3, expected_polls_per_window + 3)
 
     checker = SoftChecker()
 
+    # Per-window minimum check: ensures polls are spread throughout the test.
     window_start = test_started_at
     window_number = 0
 
@@ -1299,18 +1301,26 @@ def _check_poll_timing_for_path(
         requests_in_window = [r for r in sorted_requests if window_start <= r.timestamp < window_end]
         request_count = len(requests_in_window)
 
-        if request_count < min_polls_per_window:
+        # Only enforce the minimum on complete windows — the last partial window may naturally be sparse.
+        is_complete_window = window_end <= last_request_time
+        if is_complete_window and request_count < min_polls_per_window:
             checker.add(
                 f"Window {window_number} ({window_start.isoformat()} - {window_end.isoformat()}): "
                 f"expected at least {min_polls_per_window} poll(s), found {request_count}",
             )
-        elif request_count > max_polls_per_window:
-            checker.add(
-                f"Window {window_number} ({window_start.isoformat()} - {window_end.isoformat()}): "
-                f"expected at most {max_polls_per_window} poll(s), found {request_count}",
-            )
 
         window_start = window_end
+
+    # Global maximum check: catches excessive total polling over the whole test.
+    test_duration_seconds = (last_request_time - test_started_at).total_seconds()
+    expected_total = round(test_duration_seconds / poll_interval_seconds)
+    max_total = min(expected_total * 3, expected_total + 3)
+    total_count = len(sorted_requests)
+    if total_count > max_total:
+        checker.add(
+            f"Total polls {total_count} exceeds maximum {max_total} "
+            f"(expected ~{expected_total} over {int(test_duration_seconds)}s at {poll_interval_seconds}s interval)",
+        )
 
     return checker.finalize()
 

--- a/tests/unit/app/test_check.py
+++ b/tests/unit/app/test_check.py
@@ -3595,11 +3595,11 @@ def test_check_all_polls_at_correct_time_pagination_filtering(url: str, expected
     "offsets_seconds, expected_passed, description_contains",
     [
         ([0, 540], False, "found 0"),  # Too few: 2 requests spread over 9 minutes, empty windows
-        ([0, 30, 60, 90, 120], True, None),  # 5 requests in 3-minute window: within upper bound of 6
-        ([0, 15, 30, 45, 60, 75, 90], False, "found 7"),  # Too many: 7 requests in first 3-minute window exceeds 6
+        ([0, 30, 60, 90, 120], True, None),  # 5 requests in 3-minute window: fine
+        ([0, 15, 30, 45, 60, 75, 90], False, "Total polls"),  # 7 requests in 90s: caught by global max (expected~2, max=5)
     ],
 )
-def test_check_all_polls_at_correct_time_poll_count(
+def test_check_all_polls_at_correct_time_per_window_minimum(
     offsets_seconds: list[int], expected_passed: bool, description_contains: str | None
 ):
     base_time = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
@@ -3630,6 +3630,87 @@ def test_check_all_polls_at_correct_time_poll_count(
     if description_contains is not None:
         assert result.description is not None
         assert description_contains in result.description
+
+
+@pytest.mark.parametrize(
+    "total_polls, test_duration_seconds, expected_passed",
+    [
+        # 5-min test (expected=5): max=min(15,8)=8
+        (8, 300, True),   # exactly at max
+        (9, 300, False),  # one over
+        # 30-min test (expected=30): max=min(90,33)=33
+        (33, 1800, True),   # exactly at max
+        (34, 1800, False),  # one over
+        # 1-min test (expected=1): max=min(3,4)=3
+        (3, 60, True),
+        (4, 60, False),
+    ],
+)
+def test_check_all_polls_at_correct_time_global_maximum(
+    total_polls: int, test_duration_seconds: int, expected_passed: bool
+):
+    """Global maximum: min(expected_total * 3, expected_total + 3) over the whole test."""
+    base_time = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+    poll_interval = 60
+
+    active_test_procedure = generate_class_instance(
+        ActiveTestProcedure, started_at=base_time, step_status={}, finished_zip_path=None
+    )
+
+    # Space polls evenly so per-window minimum is always satisfied
+    offsets = [int(i * test_duration_seconds / (total_polls - 1)) for i in range(total_polls)] if total_polls > 1 else [0]
+    request_history = [
+        generate_class_instance(
+            RequestEntry,
+            seed=i,
+            path="/mup/1",
+            method=http.HTTPMethod.GET,
+            timestamp=base_time + timedelta(seconds=offset),
+        )
+        for i, offset in enumerate(offsets)
+    ]
+
+    result = check_all_polls_at_correct_time(
+        active_test_procedure,
+        request_history,
+        {"endpoint": "/mup/1", "poll_interval_seconds": poll_interval, "request_type_str": "GET"},
+    )
+
+    assert_check_result(result, expected_passed)
+    if not expected_passed:
+        assert result.description is not None
+        assert "Total polls" in result.description
+
+
+def test_check_all_polls_at_correct_time_last_window_no_false_positive():
+    """A compliant client whose last poll falls just into a new window should not be penalised."""
+    base_time = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+    poll_interval = 60
+
+    active_test_procedure = generate_class_instance(
+        ActiveTestProcedure, started_at=base_time, step_status={}, finished_zip_path=None
+    )
+
+    # Polls at 0, 60, ..., 480s then one at 541s (1s into window 4 which starts at 540s)
+    offsets = list(range(0, 481, 60)) + [541]
+    request_history = [
+        generate_class_instance(
+            RequestEntry,
+            seed=i,
+            path="/mup/1",
+            method=http.HTTPMethod.GET,
+            timestamp=base_time + timedelta(seconds=offset),
+        )
+        for i, offset in enumerate(offsets)
+    ]
+
+    result = check_all_polls_at_correct_time(
+        active_test_procedure,
+        request_history,
+        {"endpoint": "/mup/1", "poll_interval_seconds": poll_interval, "request_type_str": "GET"},
+    )
+
+    assert_check_result(result, True)
 
 
 def test_check_all_polls_at_correct_time_filters_by_request_type():

--- a/tests/unit/app/test_check.py
+++ b/tests/unit/app/test_check.py
@@ -3596,7 +3596,11 @@ def test_check_all_polls_at_correct_time_pagination_filtering(url: str, expected
     [
         ([0, 540], False, "found 0"),  # Too few: 2 requests spread over 9 minutes, empty windows
         ([0, 30, 60, 90, 120], True, None),  # 5 requests in 3-minute window: fine
-        ([0, 15, 30, 45, 60, 75, 90], False, "Total polls"),  # 7 requests in 90s: caught by global max (expected~2, max=5)
+        (
+            [0, 15, 30, 45, 60, 75, 90],
+            False,
+            "Total polls",
+        ),  # 7 requests in 90s: caught by global max (expected~2, max=5)
     ],
 )
 def test_check_all_polls_at_correct_time_per_window_minimum(
@@ -3636,10 +3640,10 @@ def test_check_all_polls_at_correct_time_per_window_minimum(
     "total_polls, test_duration_seconds, expected_passed",
     [
         # 5-min test (expected=5): max=min(15,8)=8
-        (8, 300, True),   # exactly at max
+        (8, 300, True),  # exactly at max
         (9, 300, False),  # one over
         # 30-min test (expected=30): max=min(90,33)=33
-        (33, 1800, True),   # exactly at max
+        (33, 1800, True),  # exactly at max
         (34, 1800, False),  # one over
         # 1-min test (expected=1): max=min(3,4)=3
         (3, 60, True),
@@ -3658,7 +3662,9 @@ def test_check_all_polls_at_correct_time_global_maximum(
     )
 
     # Space polls evenly so per-window minimum is always satisfied
-    offsets = [int(i * test_duration_seconds / (total_polls - 1)) for i in range(total_polls)] if total_polls > 1 else [0]
+    offsets = (
+        [int(i * test_duration_seconds / (total_polls - 1)) for i in range(total_polls)] if total_polls > 1 else [0]
+    )
     request_history = [
         generate_class_instance(
             RequestEntry,


### PR DESCRIPTION
This check still isnt implemented in the test defs but should be ready to go now.

The new plan has two checks. 

1) Min: We check every window except the last poll window have at least the expected number of polls (2 polls per 3 windows, i.e. 2 polls in 3 min window if poll rate is 1 min)

2) Max: we just check that over the lifetime of the test they do no more than min(expected_total * 3, expected_total + 3)


The new tests explicitly demonstrate these examples.