### PR TITLE
fix: missing storage extension parameters in report data

### DIFF
--- a/src/cactus_runner/models.py
+++ b/src/cactus_runner/models.py
@@ -34,7 +34,6 @@ from envoy_schema.server.schema.sep2.der import (
     NormalCategoryType,
     OperationalModeStatusType,
     StorageModeStatusType,
-    VPPControlType,
 )
 from envoy_schema.server.schema.sep2.types import (
     AccumulationBehaviourType,
@@ -325,7 +324,7 @@ class SiteDERRating(JSONWizard):
     v_nom_multiplier: int | None
     der_type: DERType
     doe_modes_supported: DOESupportedMode | None
-    vpp_modes_supported: VPPControlType | None
+    vpp_modes_supported: int | None = None
 
     @classmethod
     def from_site_der_rating(cls, rating: EnvoySiteDERRating | None) -> Self | None:
@@ -383,7 +382,7 @@ class SiteDERRating(JSONWizard):
             v_nom_multiplier=rating.v_nom_multiplier,
             der_type=rating.der_type,
             doe_modes_supported=rating.doe_modes_supported,
-            vpp_modes_supported=rating.vpp_modes_supported,
+            vpp_modes_supported=None,
         )
 
 
@@ -440,9 +439,9 @@ class SiteDERSetting(JSONWizard):
     v_ref_ofs_value: int | None
     v_ref_ofs_multiplier: int | None
     doe_modes_enabled: DOESupportedMode | None
-    vpp_modes_enabled: VPPControlType | None
-    min_wh_value: int | None
-    min_wh_multiplier: int | None
+    vpp_modes_enabled: int | None = None
+    min_wh_value: int | None = None
+    min_wh_multiplier: int | None = None
 
     @classmethod
     def from_site_der_setting(cls, setting: EnvoySiteDERSetting | None) -> Self | None:
@@ -501,9 +500,9 @@ class SiteDERSetting(JSONWizard):
             v_ref_ofs_value=setting.v_ref_ofs_value,
             v_ref_ofs_multiplier=setting.v_ref_ofs_multiplier,
             doe_modes_enabled=setting.doe_modes_enabled,
-            vpp_modes_enabled=setting.vpp_modes_enabled,
-            min_wh_value=setting.min_wh_value,
-            min_wh_multiplier=setting.min_wh_multiplier,
+            vpp_modes_enabled=None,
+            min_wh_value=None,
+            min_wh_multiplier=None,
         )
 
 

--- a/src/cactus_runner/models.py
+++ b/src/cactus_runner/models.py
@@ -34,6 +34,7 @@ from envoy_schema.server.schema.sep2.der import (
     NormalCategoryType,
     OperationalModeStatusType,
     StorageModeStatusType,
+    VPPControlType,
 )
 from envoy_schema.server.schema.sep2.types import (
     AccumulationBehaviourType,
@@ -324,6 +325,7 @@ class SiteDERRating(JSONWizard):
     v_nom_multiplier: int | None
     der_type: DERType
     doe_modes_supported: DOESupportedMode | None
+    vpp_modes_supported: VPPControlType | None
 
     @classmethod
     def from_site_der_rating(cls, rating: EnvoySiteDERRating | None) -> Self | None:
@@ -381,6 +383,7 @@ class SiteDERRating(JSONWizard):
             v_nom_multiplier=rating.v_nom_multiplier,
             der_type=rating.der_type,
             doe_modes_supported=rating.doe_modes_supported,
+            vpp_modes_supported=rating.vpp_modes_supported,
         )
 
 
@@ -437,6 +440,9 @@ class SiteDERSetting(JSONWizard):
     v_ref_ofs_value: int | None
     v_ref_ofs_multiplier: int | None
     doe_modes_enabled: DOESupportedMode | None
+    vpp_modes_enabled: VPPControlType | None
+    min_wh_value: int | None
+    min_wh_multiplier: int | None
 
     @classmethod
     def from_site_der_setting(cls, setting: EnvoySiteDERSetting | None) -> Self | None:
@@ -495,6 +501,9 @@ class SiteDERSetting(JSONWizard):
             v_ref_ofs_value=setting.v_ref_ofs_value,
             v_ref_ofs_multiplier=setting.v_ref_ofs_multiplier,
             doe_modes_enabled=setting.doe_modes_enabled,
+            vpp_modes_enabled=setting.vpp_modes_enabled,
+            min_wh_value=setting.min_wh_value,
+            min_wh_multiplier=setting.min_wh_multiplier,
         )
 
 

--- a/tests/data/xml/edev_agg.xml
+++ b/tests/data/xml/edev_agg.xml
@@ -1,0 +1,5 @@
+<EndDevice xmlns="urn:ieee:std:2030.5:ns">
+    <lFDI>854d10a201ca99e5e90d3c3e1f9bc1c300000666</lFDI>
+    <sFDI>35915311648</sFDI>
+    <changedTime>1759733047</changedTime>
+</EndDevice>

--- a/tests/data/xml/mup_agg.xml
+++ b/tests/data/xml/mup_agg.xml
@@ -1,0 +1,21 @@
+<MirrorUsagePoint xmlns="urn:ieee:std:2030.5:ns">
+	<mRID>0600006C</mRID>
+	<description>Max Watts</description>
+	<roleFlags>03</roleFlags>
+	<serviceCategoryKind>0</serviceCategoryKind>
+	<status>1</status>
+	<deviceLFDI>854d10a201ca99e5e90d3c3e1f9bc1c300000666</deviceLFDI>
+	<MirrorMeterReading>
+		<mRID>0700006C</mRID>
+		<ReadingType>
+			<accumulationBehaviour>9</accumulationBehaviour>
+			<commodity>1</commodity>
+			<dataQualifier>2</dataQualifier>
+			<flowDirection>1</flowDirection>
+            <intervalLength>300</intervalLength>
+			<powerOfTenMultiplier>3</powerOfTenMultiplier>
+			<uom>38</uom>
+			<kind>37</kind>
+		</ReadingType>
+	</MirrorMeterReading>
+</MirrorUsagePoint>

--- a/tests/integration/test_all_01_with_readings.py
+++ b/tests/integration/test_all_01_with_readings.py
@@ -13,6 +13,7 @@ from envoy.server.model.site_reading import SiteReading, SiteReadingType
 from pytest_aiohttp.plugin import TestClient
 from sqlalchemy import func, select
 
+from cactus_runner.app import env
 from cactus_runner.client import RunnerClient
 from tests.integration.certificate1 import TEST_CERTIFICATE_PEM
 from tests.integration.test_all_01 import assert_success_response
@@ -37,8 +38,9 @@ async def test_all_01_with_readings(
 
     # Load XML data from files
     xml_data_dir = Path(__file__).parent.parent / "data" / "xml"
-    edev_xml = (xml_data_dir / "edev.xml").read_text().strip()
+    edev_xml = (xml_data_dir / "edev_agg.xml").read_text().strip()
     mup_xml = (xml_data_dir / "mup.xml").read_text().strip()
+    mup_agg_xml = (xml_data_dir / "mup_agg.xml").read_text().strip()
     mmr_xml = (xml_data_dir / "mmr.xml").read_text().strip()
 
     # SETUP: The real ALL_01 (from test_all_01.py)
@@ -67,13 +69,14 @@ async def test_all_01_with_readings(
     # Register the device (required for aggregator certificate)
     if certificate_type == "aggregator_certificate":
         result = await cactus_runner_client.post(
-            "/edev", data=edev_xml, headers={"ssl-client-cert": URI_ENCODED_CERT, "Content-Type": "application/sep+xml"}
+            "/edev", data=edev_xml, headers={"ssl-client-cert": URI_ENCODED_CERT, "Content-Type": env.HEADER_MEDIA_ALL}
         )
         await assert_success_response(result)
 
     # Post Mirror Usage Point
+    mup_data = mup_agg_xml if certificate_type == "aggregator_certificate" else mup_xml
     result = await cactus_runner_client.post(
-        "/mup", data=mup_xml, headers={"ssl-client-cert": URI_ENCODED_CERT, "Content-Type": "application/sep+xml"}
+        "/mup", data=mup_data, headers={"ssl-client-cert": URI_ENCODED_CERT, "Content-Type": env.HEADER_MEDIA_ALL}
     )
     location = result.headers.get("Location")
     assert location is not None
@@ -84,7 +87,7 @@ async def test_all_01_with_readings(
     result: ClientResponse = await cactus_runner_client.post(
         f"/mup/{mup_id}",
         data=mmr_xml,
-        headers={"ssl-client-cert": URI_ENCODED_CERT, "Content-Type": "application/sep+xml"},
+        headers={"ssl-client-cert": URI_ENCODED_CERT, "Content-Type": env.HEADER_MEDIA_ALL},
     )
     await assert_success_response(result)
 

--- a/tests/integration/test_all_01_with_readings.py
+++ b/tests/integration/test_all_01_with_readings.py
@@ -13,7 +13,6 @@ from envoy.server.model.site_reading import SiteReading, SiteReadingType
 from pytest_aiohttp.plugin import TestClient
 from sqlalchemy import func, select
 
-from cactus_runner.app import env
 from cactus_runner.client import RunnerClient
 from tests.integration.certificate1 import TEST_CERTIFICATE_PEM
 from tests.integration.test_all_01 import assert_success_response
@@ -69,14 +68,14 @@ async def test_all_01_with_readings(
     # Register the device (required for aggregator certificate)
     if certificate_type == "aggregator_certificate":
         result = await cactus_runner_client.post(
-            "/edev", data=edev_xml, headers={"ssl-client-cert": URI_ENCODED_CERT, "Content-Type": env.HEADER_MEDIA_ALL}
+            "/edev", data=edev_xml, headers={"ssl-client-cert": URI_ENCODED_CERT, "Content-Type": "application/sep+xml"}
         )
         await assert_success_response(result)
 
     # Post Mirror Usage Point
     mup_data = mup_agg_xml if certificate_type == "aggregator_certificate" else mup_xml
     result = await cactus_runner_client.post(
-        "/mup", data=mup_data, headers={"ssl-client-cert": URI_ENCODED_CERT, "Content-Type": env.HEADER_MEDIA_ALL}
+        "/mup", data=mup_data, headers={"ssl-client-cert": URI_ENCODED_CERT, "Content-Type": "application/sep+xml"}
     )
     location = result.headers.get("Location")
     assert location is not None
@@ -87,7 +86,7 @@ async def test_all_01_with_readings(
     result: ClientResponse = await cactus_runner_client.post(
         f"/mup/{mup_id}",
         data=mmr_xml,
-        headers={"ssl-client-cert": URI_ENCODED_CERT, "Content-Type": env.HEADER_MEDIA_ALL},
+        headers={"ssl-client-cert": URI_ENCODED_CERT, "Content-Type": "application/sep+xml"},
     )
     await assert_success_response(result)
 

--- a/tests/integration/test_all_07.py
+++ b/tests/integration/test_all_07.py
@@ -48,7 +48,7 @@ async def test_all_07_full(cactus_runner_client: TestClient, run_request_generat
         "/edev",
         headers={"ssl-client-cert": URI_ENCODED_CERT},
         data=EndDeviceRequest(
-            lFDI="854d10a201ca99e5e90d3c3e1f9bc1c3bd075f3b", sFDI=357827241281, changedTime=1766110684
+            lFDI="854d10a201ca99e5e90d3c3e1f9bc1c300000666", sFDI=357827241281, changedTime=1766110684
         ).to_xml(skip_empty=True, exclude_none=True),
     )
     await assert_success_response(result)

--- a/tests/integration/test_concurrent_requests.py
+++ b/tests/integration/test_concurrent_requests.py
@@ -99,10 +99,12 @@ async def test_twenty_concurrent_gets_all_listeners_triggered(cactus_runner_clie
 
     result = await cactus_runner_client.post(
         "/edev",
-        headers={"ssl-client-cert": URI_ENCODED_CERT},
-        data=EndDeviceRequest(lFDI=TEST_CERTIFICATE_LFDI, sFDI=357827241281, changedTime=1766110684).to_xml(
-            skip_empty=True, exclude_none=True
-        ),
+        headers={
+            "ssl-client-cert": URI_ENCODED_CERT,
+        },
+        data=EndDeviceRequest(
+            lFDI=f"{TEST_CERTIFICATE_LFDI[:32]}{666:08d}", sFDI=357827241281, changedTime=1766110684
+        ).to_xml(skip_empty=True, exclude_none=True),
     )
     assert result.status < 300
 


### PR DESCRIPTION
Originally raised by @joecrowley-synergy With https://github.com/bsgip/cactus-runner/pull/182

Migrated to doing it from main initially and then forward porting it to v1.3 - this version includes defaults for the new fields so that it doesn't break with older JSON formats

Also preempting the problems that may come up with updating envoy when aggregator lfdi clash checks may become a problem. These changes are more representative of the requests that would occur from an aggregator client.

Synergy reference
AB#232040