### PR TITLE
Warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 dependencies = [
   "aiohttp>=3.11.12,<4",
-  "cactus-schema @ git+https://github.com/bsgip/cactus-schema.git@9dbe6d2be947fc91bd3a2307cb230665c00b0763",
+  "cactus-schema @ git+https://github.com/bsgip/cactus-schema.git@v1.3.2",
   "cactus-test-definitions>=1.15.0,<2",
   "envoy @ git+https://github.com/bsgip/envoy.git@v1.5.0",
   "psycopg[binary]>=3.2.5,<4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 dependencies = [
   "aiohttp>=3.11.12,<4",
-  "cactus-schema>=1.3.1,<2",
+  "cactus-schema @ git+https://github.com/bsgip/cactus-schema.git@e5b7003a9d2efef9f226b7b548a56471347af2da",
   "cactus-test-definitions>=1.15.0,<2",
   "envoy @ git+https://github.com/bsgip/envoy.git@v1.5.0",
   "psycopg[binary]>=3.2.5,<4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 dependencies = [
   "aiohttp>=3.11.12,<4",
-  "cactus-schema @ git+https://github.com/bsgip/cactus-schema.git@e5b7003a9d2efef9f226b7b548a56471347af2da",
+  "cactus-schema @ git+https://github.com/bsgip/cactus-schema.git@9dbe6d2be947fc91bd3a2307cb230665c00b0763",
   "cactus-test-definitions>=1.15.0,<2",
   "envoy @ git+https://github.com/bsgip/envoy.git@v1.5.0",
   "psycopg[binary]>=3.2.5,<4",

--- a/src/cactus_runner/app/finalize.py
+++ b/src/cactus_runner/app/finalize.py
@@ -10,10 +10,7 @@ from pathlib import Path
 from typing import cast
 
 import pandas as pd
-from cactus_schema.runner.schema import RequestEntry
-from envoy.server.model.archive.site import ArchiveSiteDERSetting
-from envoy.server.model.site import SiteDERSetting
-from sqlalchemy import select
+from cactus_schema.runner.schema import RequestEntry, WarningEntry
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from cactus_runner.app import check, timeline
@@ -37,6 +34,7 @@ from cactus_runner.app.readings import (
 )
 from cactus_runner.app.requests_archive import copy_request_response_files_to_archive
 from cactus_runner.app.status import get_active_runner_status
+from cactus_runner.app.warning import run_post_test_analysers
 from cactus_runner.models import (
     CheckResult,
     PackedReadings,
@@ -90,6 +88,14 @@ def get_file_name_no_extension(file_path: str) -> str:
         return ".".join(dot_parts[:-1])
 
 
+def _format_warnings_txt(warnings: list[WarningEntry]) -> str:
+    """Human-readable printout of warnings for the artifact zip - one block per warning."""
+    blocks = []
+    for w in warnings:
+        blocks.append(f"Type: {w.type}\nTimestamp: {w.timestamp.isoformat()}\n{w.description}\n\n{w.message}")
+    return "\n\n---\n\n".join(blocks)
+
+
 def write_zip_to_file(
     output_path: Path,
     json_status_summary: str | None,
@@ -98,6 +104,7 @@ def write_zip_to_file(
     errors: list[str],
     filename_infix: str = "",
     reporting_data_filename_prefix: str | None = "ReportingData",
+    warnings: list[WarningEntry] | None = None,
 ) -> None:
     """Writes the zipped test procedure artifacts to output_path."""
 
@@ -117,6 +124,12 @@ def write_zip_to_file(
             file_path = archive_dir / f"{reporting_data_filename_prefix}{filename_infix}.json"
             with open(file_path, "w") as f:
                 f.write(json_reporting_data)
+
+        # Create human-readable warnings printout (omitted if no warnings)
+        if warnings:
+            file_path = archive_dir / f"warnings{filename_infix}.txt"
+            with open(file_path, "w") as f:
+                f.write(_format_warnings_txt(warnings))
 
         # Copy log files into the archive (use tail if larger than MAX_LOG_FILE_BYTES)
         for log_file_path in log_file_paths:
@@ -200,7 +213,7 @@ async def generate_json_reporting_data(
     timeline: timeline.Timeline | None,
     errors: list[str],
     version: int = 1,
-    set_max_w_varied: bool = False,
+    warnings: list[WarningEntry] | None = None,
 ) -> str | None:
     created_at = datetime.now(UTC)
 
@@ -220,7 +233,7 @@ async def generate_json_reporting_data(
             readings=packed_readings,  # ty:ignore[unknown-argument]
             sites=sites,  # ty:ignore[unknown-argument]
             timeline=timeline,  # ty:ignore[unknown-argument]
-            set_max_w_varied=set_max_w_varied,  # ty:ignore[unknown-argument]
+            warnings=warnings if warnings is not None else [],  # ty:ignore[unknown-argument]
         )
         json_reporting_data = reporting_data.to_json()
     except Exception as exc:
@@ -256,6 +269,9 @@ async def finish_active_test(runner_state: RunnerState, session: AsyncSession) -
     logger.info(f"finish_active_test_procedure: '{active_test_procedure.name}' will be finished")
 
     capped_request_history = _cap_request_history(runner_state.request_history)
+
+    # Run finalize-time warning analysers so status/reporting/zip all see the final warning set
+    await run_post_test_analysers(session, active_test_procedure, capped_request_history)
 
     # Collect status summary
     try:
@@ -318,20 +334,6 @@ async def finish_active_test(runner_state: RunnerState, session: AsyncSession) -
         readings = await get_readings(session, reading_specifiers=MANDATORY_READING_SPECIFIERS)
         reading_counts = await get_reading_counts_grouped_by_reading_type(session)
 
-        # Check if setMaxW was varied during the test - any archive entry with a different max_w_value
-        # than the current SiteDERSetting for the same site means it changed
-        set_max_w_varied = (
-            await session.execute(
-                select(ArchiveSiteDERSetting.site_id)
-                .join(
-                    SiteDERSetting,
-                    (SiteDERSetting.site_id == ArchiveSiteDERSetting.site_id)  # Same DER (one per site)
-                    & (SiteDERSetting.max_w_value != ArchiveSiteDERSetting.max_w_value),  # Same setmaxw
-                )
-                .limit(1)
-            )
-        ).scalar() is not None
-
         capped_runner_state = dataclasses.replace(runner_state, request_history=capped_request_history)
 
         # Convert to serialisable types
@@ -350,7 +352,7 @@ async def finish_active_test(runner_state: RunnerState, session: AsyncSession) -
             timeline=test_timeline,
             errors=errors,
             version=reporting_data_version,
-            set_max_w_varied=set_max_w_varied,
+            warnings=list(active_test_procedure.warnings.values()),
         )
         reporting_data_filename_prefix = f"ReportingData_v{reporting_data_version}"
     except Exception as exc:
@@ -377,6 +379,7 @@ async def finish_active_test(runner_state: RunnerState, session: AsyncSession) -
         filename_infix=f"_{int(generation_timestamp.timestamp())}_{active_test_procedure.name}",
         reporting_data_filename_prefix=reporting_data_filename_prefix,
         errors=errors,
+        warnings=list(active_test_procedure.warnings.values()),
     )
     active_test_procedure.finished_zip_path = zip_path
     return zip_path

--- a/src/cactus_runner/app/status.py
+++ b/src/cactus_runner/app/status.py
@@ -389,6 +389,7 @@ async def get_active_runner_status(
         request_history=request_history,
         timeline=timeline,
         end_device_metadata=end_device_metadata,
+        warnings=list(active_test_procedure.warnings.values()),
     )
 
 

--- a/src/cactus_runner/app/warning.py
+++ b/src/cactus_runner/app/warning.py
@@ -4,8 +4,10 @@ from datetime import UTC, datetime
 
 from cactus_schema.runner import RequestEntry, WarningEntry
 from envoy.server.model.archive.site import ArchiveSiteDERSetting
+from envoy.server.model.archive.site_reading import ArchiveSiteReadingType
 from envoy.server.model.site import SiteDERSetting
-from sqlalchemy import func, select
+from envoy.server.model.site_reading import SiteReadingType
+from sqlalchemy import func, inspect, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from cactus_runner.models import ActiveTestProcedure
@@ -73,7 +75,40 @@ async def _analyse_der_settings_varied(
         )
 
 
-POST_TEST_ANALYSERS: list[PostTestAnalyser] = [_analyse_der_settings_varied]
+async def _analyse_reading_type_varied(
+    session: AsyncSession, active_test_procedure: ActiveTestProcedure, request_history: list[RequestEntry]
+) -> None:
+    """Flags if a MirrorUsagePoint's ReadingType changed during the test."""
+    pairs = (
+        await session.execute(
+            select(SiteReadingType, ArchiveSiteReadingType).join(
+                ArchiveSiteReadingType,
+                ArchiveSiteReadingType.site_reading_type_id == SiteReadingType.site_reading_type_id,
+            )
+        )
+    ).all()
+
+    field_names = [c.key for c in inspect(SiteReadingType).mapper.column_attrs]
+    varied_fields = {
+        field
+        for current, archived in pairs
+        for field in field_names
+        if getattr(current, field) != getattr(archived, field)
+    }
+
+    if varied_fields:
+        warn(
+            active_test_procedure,
+            "reading-type.varied",
+            "A reading type changed during the test",
+            f"The {', '.join(sorted(varied_fields))} field(s) of a MirrorUsagePoint's ReadingType changed at "
+            "least once during the test. This updates the reading type for all associated readings, including "
+            "historical ones already submitted. Please ensure you do not update reading types unless your "
+            "previous readings were submitted incorrectly.",
+        )
+
+
+POST_TEST_ANALYSERS: list[PostTestAnalyser] = [_analyse_der_settings_varied, _analyse_reading_type_varied]
 
 
 async def run_post_test_analysers(

--- a/src/cactus_runner/app/warning.py
+++ b/src/cactus_runner/app/warning.py
@@ -1,0 +1,87 @@
+import logging
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+
+from cactus_schema.runner import RequestEntry, WarningEntry
+from envoy.server.model.archive.site import ArchiveSiteDERSetting
+from envoy.server.model.site import SiteDERSetting
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cactus_runner.models import ActiveTestProcedure
+
+logger = logging.getLogger(__name__)
+
+
+def warn(active_test_procedure: ActiveTestProcedure, type: str, description: str, message: str) -> None:  # noqa: A002
+    """Records a WarningEntry against the active test procedure. Warnings never affect pass/fail.
+
+    First-write-wins per `type` - if a warning with this type has already been recorded, this call is a no-op."""
+    if type in active_test_procedure.warnings:
+        return
+    active_test_procedure.warnings[type] = WarningEntry(
+        type=type, description=description, message=message, timestamp=datetime.now(UTC)
+    )
+
+
+PostTestAnalyser = Callable[[AsyncSession, ActiveTestProcedure, list[RequestEntry]], Awaitable[None]]
+
+
+# DERSettings fields checked for variation, mapped to their sep2 name for use in the warning message
+_DER_SETTINGS_VARIED_FIELDS = {
+    "setMaxW": (SiteDERSetting.max_w_value, ArchiveSiteDERSetting.max_w_value),
+    "setMaxChargeRateW": (SiteDERSetting.max_charge_rate_w_value, ArchiveSiteDERSetting.max_charge_rate_w_value),
+    "setMaxDischargeRateW": (
+        SiteDERSetting.max_discharge_rate_w_value,
+        ArchiveSiteDERSetting.max_discharge_rate_w_value,
+    ),
+}
+
+
+async def _analyse_der_settings_varied(
+    session: AsyncSession, active_test_procedure: ActiveTestProcedure, request_history: list[RequestEntry]
+) -> None:
+    """Flags if setMaxW/setMaxChargeRateW/setMaxDischargeRateW (DERSettings) changed at least once during the
+    test - any archived DER setting with a different value than the current value for the same site means it
+    changed. The warning message names exactly which field(s) varied."""
+    varied_fields = []
+    for label, (current_column, archived_column) in _DER_SETTINGS_VARIED_FIELDS.items():
+        varied = (
+            await session.execute(
+                select(ArchiveSiteDERSetting.site_id)
+                .join(
+                    SiteDERSetting,
+                    (SiteDERSetting.site_id == ArchiveSiteDERSetting.site_id)  # Same DER (one per site)
+                    & (current_column != archived_column),
+                )
+                .limit(1)
+            )
+        ).scalar() is not None
+        if varied:
+            varied_fields.append(label)
+
+    if varied_fields:
+        warn(
+            active_test_procedure,
+            "der-settings.set-max-w-varied",
+            "setMaxW changed during the test",
+            f"The DER's {', '.join(varied_fields)} (DERSettings) value changed at least once during the test. "
+            "Altering these values is not standard practise. Site controls in tests use these values to create "
+            "control limits, altering them may cause you to fail CACTUS tests.",
+        )
+
+
+POST_TEST_ANALYSERS: list[PostTestAnalyser] = [_analyse_der_settings_varied]
+
+
+async def run_post_test_analysers(
+    session: AsyncSession, active_test_procedure: ActiveTestProcedure, request_history: list[RequestEntry]
+) -> None:
+    """Runs every registered post-test analyser once, for use at test finalisation. Each analyser calls warn() to
+    record any warnings it finds. Exceptions are caught and logged per-analyser so one failing analyser can't
+    prevent the others (or the rest of finalisation) from running."""
+    for analyser in POST_TEST_ANALYSERS:
+        try:
+            await analyser(session, active_test_procedure, request_history)
+        except Exception as exc:
+            logger.error(f"Error running post test analyser {analyser}", exc_info=exc)

--- a/src/cactus_runner/app/warning.py
+++ b/src/cactus_runner/app/warning.py
@@ -5,7 +5,7 @@ from datetime import UTC, datetime
 from cactus_schema.runner import RequestEntry, WarningEntry
 from envoy.server.model.archive.site import ArchiveSiteDERSetting
 from envoy.server.model.site import SiteDERSetting
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from cactus_runner.models import ActiveTestProcedure
@@ -44,21 +44,23 @@ async def _analyse_der_settings_varied(
     """Flags if setMaxW/setMaxChargeRateW/setMaxDischargeRateW (DERSettings) changed at least once during the
     test - any archived DER setting with a different value than the current value for the same site means it
     changed. The warning message names exactly which field(s) varied."""
-    varied_fields = []
-    for label, (current_column, archived_column) in _DER_SETTINGS_VARIED_FIELDS.items():
-        varied = (
-            await session.execute(
-                select(ArchiveSiteDERSetting.site_id)
-                .join(
-                    SiteDERSetting,
-                    (SiteDERSetting.site_id == ArchiveSiteDERSetting.site_id)  # Same DER (one per site)
-                    & (current_column != archived_column),
+    labels = list(_DER_SETTINGS_VARIED_FIELDS.keys())
+    row = (
+        await session.execute(
+            select(
+                *(
+                    func.bool_or(current_column != archived_column)
+                    for current_column, archived_column in _DER_SETTINGS_VARIED_FIELDS.values()
                 )
-                .limit(1)
             )
-        ).scalar() is not None
-        if varied:
-            varied_fields.append(label)
+            .select_from(ArchiveSiteDERSetting)
+            .join(
+                SiteDERSetting,
+                SiteDERSetting.site_id == ArchiveSiteDERSetting.site_id,  # Same DER (one per site)
+            )
+        )
+    ).one()
+    varied_fields = [label for label, is_varied in zip(labels, row, strict=True) if is_varied]
 
     if varied_fields:
         warn(

--- a/src/cactus_runner/models.py
+++ b/src/cactus_runner/models.py
@@ -10,6 +10,7 @@ from cactus_schema.runner import (
     ClientInteractionType,
     RequestEntry,
     StepStatus,
+    WarningEntry,
 )
 from cactus_test_definitions import CSIPAusVersion
 from cactus_test_definitions.client import Event, TestProcedure
@@ -136,6 +137,7 @@ class ActiveTestProcedure:
     resource_annotations: ResourceAnnotations = field(default_factory=ResourceAnnotations)
     random_values: RandomValues = field(default_factory=RandomValues)
     proxy_route_overrides: list[ProxyRouteOverride] = field(default_factory=list)
+    warnings: dict[str, WarningEntry] = field(default_factory=dict)
 
     def is_finished(self) -> bool:
         """True if the active test procedure has been marked as finished. That is, there is no more test data to
@@ -713,4 +715,4 @@ class ReportingData_v1(ReportingData_Base):  # noqa: N801
     readings: list[PackedReadings]
     sites: list[Site]
     timeline: Timeline | None
-    set_max_w_varied: bool = False
+    warnings: list[WarningEntry] = field(default_factory=list)

--- a/tests/unit/app/test_finalize.py
+++ b/tests/unit/app/test_finalize.py
@@ -11,7 +11,7 @@ import pytest
 from assertical.asserts.generator import assert_class_instance_equality
 from assertical.asserts.time import assert_nowish
 from assertical.fake.generator import generate_class_instance
-from cactus_schema.runner.schema import RequestEntry
+from cactus_schema.runner.schema import RequestEntry, WarningEntry
 
 from cactus_runner.app import finalize
 from cactus_runner.app.timeline import Timeline
@@ -249,6 +249,7 @@ async def test_generate_json_reporting_data(version):
     sites = [generate_class_instance(Site) for _ in range(site_count)]
     timeline = None
     errors = []
+    warnings = [generate_class_instance(WarningEntry, seed=i) for i in range(2)]
 
     # Act
     reporting_data_str = await finalize.generate_json_reporting_data(
@@ -260,6 +261,7 @@ async def test_generate_json_reporting_data(version):
         timeline=timeline,
         errors=errors,
         version=version,
+        warnings=warnings,
     )
     assert reporting_data_str is not None
     reporting_data = ReportingData.from_json(version, reporting_data_str)
@@ -272,6 +274,26 @@ async def test_generate_json_reporting_data(version):
     assert len(readings) == len(reporting_data.readings)
     assert_class_instance_equality(list[Site], sites, reporting_data.sites)
     assert_class_instance_equality(Timeline, timeline, reporting_data.timeline)
+    assert_class_instance_equality(list[WarningEntry], warnings, reporting_data.warnings)
+
+
+@pytest.mark.asyncio
+async def test_generate_json_reporting_data_defaults_warnings_to_empty_list():
+    runner_state = RunnerState()
+
+    reporting_data_str = await finalize.generate_json_reporting_data(
+        runner_state=runner_state,
+        check_results={},
+        readings={},
+        reading_counts={},
+        sites=[],
+        timeline=None,
+        errors=[],
+        version=1,
+    )
+    assert reporting_data_str is not None
+    reporting_data = ReportingData.from_json(1, reporting_data_str)
+    assert reporting_data.warnings == []
 
 
 def test_cap_request_history_within_limit(mocker):

--- a/tests/unit/app/test_status.py
+++ b/tests/unit/app/test_status.py
@@ -153,6 +153,7 @@ async def test_get_active_runner_status_calls_get_runner_status_summary(mocker):
     active_test_procedure.definition.criteria = None
     active_test_procedure.definition.preconditions.checks = None
     active_test_procedure.listeners = []
+    active_test_procedure.warnings = {}
     request_history = Mock()
     last_client_interaction = Mock()
 

--- a/tests/unit/app/test_warning.py
+++ b/tests/unit/app/test_warning.py
@@ -1,0 +1,187 @@
+from datetime import UTC, datetime
+
+import pytest
+from assertical.asserts.time import assert_nowish
+from assertical.fake.generator import generate_class_instance
+from assertical.fixtures.postgres import generate_async_session
+from cactus_schema.runner import WarningEntry
+from envoy.server.model.archive.site import ArchiveSiteDERSetting
+from envoy.server.model.site import Site, SiteDERSetting
+
+from cactus_runner.app.warning import (
+    POST_TEST_ANALYSERS,
+    _analyse_der_settings_varied,
+    run_post_test_analysers,
+    warn,
+)
+from cactus_runner.models import ActiveTestProcedure
+
+
+def _make_active_test_procedure() -> ActiveTestProcedure:
+    return generate_class_instance(ActiveTestProcedure, step_status={}, finished_zip_path=None, warnings={})
+
+
+def test_warn_adds_new_entry():
+    active_test_procedure = _make_active_test_procedure()
+
+    warn(active_test_procedure, "der-settings.set-max-w-varied", "short description", "full message")
+
+    assert list(active_test_procedure.warnings.keys()) == ["der-settings.set-max-w-varied"]
+    entry = active_test_procedure.warnings["der-settings.set-max-w-varied"]
+    assert isinstance(entry, WarningEntry)
+    assert entry.type == "der-settings.set-max-w-varied"
+    assert entry.description == "short description"
+    assert entry.message == "full message"
+    assert_nowish(entry.timestamp)
+
+
+def test_warn_is_first_write_wins():
+    """A second warn() call with the same type should be a silent no-op - the first message/timestamp is kept"""
+    active_test_procedure = _make_active_test_procedure()
+
+    warn(active_test_procedure, "polling.too-frequent./dcap", "first description", "first message")
+    first_entry = active_test_procedure.warnings["polling.too-frequent./dcap"]
+
+    warn(active_test_procedure, "polling.too-frequent./dcap", "second description", "second message")
+
+    assert len(active_test_procedure.warnings) == 1
+    entry = active_test_procedure.warnings["polling.too-frequent./dcap"]
+    assert entry is first_entry
+    assert entry.description == "first description"
+    assert entry.message == "first message"
+
+
+def test_warn_distinct_types_both_kept():
+    active_test_procedure = _make_active_test_procedure()
+
+    warn(active_test_procedure, "der-settings.set-max-w-varied", "d1", "m1")
+    warn(active_test_procedure, "polling.too-frequent./dcap", "d2", "m2")
+
+    assert set(active_test_procedure.warnings.keys()) == {
+        "der-settings.set-max-w-varied",
+        "polling.too-frequent./dcap",
+    }
+
+
+@pytest.mark.anyio
+async def test_run_post_test_analysers_catches_analyser_exceptions(mocker):
+    """A failing analyser must not prevent the others from running"""
+    active_test_procedure = _make_active_test_procedure()
+
+    async def _boom(session, active_test_procedure, request_history):
+        raise ValueError("analyser blew up")
+
+    async def _good(session, active_test_procedure, request_history):
+        warn(active_test_procedure, "some.type", "d", "m")
+
+    mocker.patch("cactus_runner.app.warning.POST_TEST_ANALYSERS", [_boom, _good])
+
+    await run_post_test_analysers(
+        session=mocker.Mock(), active_test_procedure=active_test_procedure, request_history=[]
+    )
+
+    assert "some.type" in active_test_procedure.warnings
+
+
+@pytest.mark.anyio
+async def test_analyse_der_settings_varied_no_warning_when_unchanged(pg_base_config):
+    active_test_procedure = _make_active_test_procedure()
+
+    async with generate_async_session(pg_base_config) as session:
+        site = generate_class_instance(Site, seed=101, aggregator_id=1)
+        session.add(site)
+        await session.flush()
+
+        site.site_der_setting = generate_class_instance(
+            SiteDERSetting,
+            seed=202,
+            site_id=site.site_id,
+            max_w_value=5000,
+            max_charge_rate_w_value=1000,
+            max_discharge_rate_w_value=1000,
+        )
+        session.add(site.site_der_setting)
+
+        # Archived entry has identical values - not a change
+        session.add(
+            generate_class_instance(
+                ArchiveSiteDERSetting,
+                seed=303,
+                site_id=site.site_id,
+                archive_id=1,
+                archive_time=datetime.now(UTC),
+                deleted_time=None,
+                max_w_value=5000,
+                max_charge_rate_w_value=1000,
+                max_discharge_rate_w_value=1000,
+            )
+        )
+        await session.commit()
+
+    async with generate_async_session(pg_base_config) as session:
+        await _analyse_der_settings_varied(session, active_test_procedure, [])
+
+    assert active_test_procedure.warnings == {}
+
+
+@pytest.mark.parametrize(
+    "current_max_w, archived_max_w, current_charge, archived_charge, "
+    "current_discharge, archived_discharge, expected_field",
+    [
+        (5000, 4000, 1000, 1000, 1000, 1000, "setMaxW"),
+        (5000, 5000, 1000, 900, 1000, 1000, "setMaxChargeRateW"),
+        (5000, 5000, 1000, 1000, 1000, 800, "setMaxDischargeRateW"),
+    ],
+)
+@pytest.mark.anyio
+async def test_analyse_der_settings_varied_warns_when_any_value_changed(
+    pg_base_config,
+    current_max_w: int,
+    archived_max_w: int,
+    current_charge: int,
+    archived_charge: int,
+    current_discharge: int,
+    archived_discharge: int,
+    expected_field: str,
+):
+    active_test_procedure = _make_active_test_procedure()
+
+    async with generate_async_session(pg_base_config) as session:
+        site = generate_class_instance(Site, seed=101, aggregator_id=1)
+        session.add(site)
+        await session.flush()
+
+        site.site_der_setting = generate_class_instance(
+            SiteDERSetting,
+            seed=202,
+            site_id=site.site_id,
+            max_w_value=current_max_w,
+            max_charge_rate_w_value=current_charge,
+            max_discharge_rate_w_value=current_discharge,
+        )
+        session.add(site.site_der_setting)
+
+        session.add(
+            generate_class_instance(
+                ArchiveSiteDERSetting,
+                seed=303,
+                site_id=site.site_id,
+                archive_id=1,
+                archive_time=datetime.now(UTC),
+                deleted_time=None,
+                max_w_value=archived_max_w,
+                max_charge_rate_w_value=archived_charge,
+                max_discharge_rate_w_value=archived_discharge,
+            )
+        )
+        await session.commit()
+
+    async with generate_async_session(pg_base_config) as session:
+        await _analyse_der_settings_varied(session, active_test_procedure, [])
+
+    assert list(active_test_procedure.warnings.keys()) == ["der-settings.set-max-w-varied"]
+    assert expected_field in active_test_procedure.warnings["der-settings.set-max-w-varied"].message
+
+
+def test_analyse_der_settings_varied_is_registered():
+    assert _analyse_der_settings_varied in POST_TEST_ANALYSERS

--- a/tests/unit/app/test_warning.py
+++ b/tests/unit/app/test_warning.py
@@ -6,11 +6,15 @@ from assertical.fake.generator import generate_class_instance
 from assertical.fixtures.postgres import generate_async_session
 from cactus_schema.runner import WarningEntry
 from envoy.server.model.archive.site import ArchiveSiteDERSetting
+from envoy.server.model.archive.site_reading import ArchiveSiteReadingType
 from envoy.server.model.site import Site, SiteDERSetting
+from envoy.server.model.site_reading import SiteReadingType
+from sqlalchemy import inspect
 
 from cactus_runner.app.warning import (
     POST_TEST_ANALYSERS,
     _analyse_der_settings_varied,
+    _analyse_reading_type_varied,
     run_post_test_analysers,
     warn,
 )
@@ -185,3 +189,75 @@ async def test_analyse_der_settings_varied_warns_when_any_value_changed(
 
 def test_analyse_der_settings_varied_is_registered():
     assert _analyse_der_settings_varied in POST_TEST_ANALYSERS
+
+
+@pytest.mark.anyio
+async def test_analyse_reading_type_varied_no_warning_when_unchanged(pg_base_config):
+    active_test_procedure = _make_active_test_procedure()
+
+    async with generate_async_session(pg_base_config) as session:
+        site = generate_class_instance(Site, seed=101, aggregator_id=1)
+        session.add(site)
+        await session.flush()
+
+        srt = generate_class_instance(SiteReadingType, seed=202, site=site, aggregator_id=1)
+        session.add(srt)
+        await session.flush()
+
+        # Archived entry copies every shared column from srt unchanged - not a change
+        shared_values = {c.key: getattr(srt, c.key) for c in inspect(SiteReadingType).mapper.column_attrs}
+        session.add(
+            generate_class_instance(
+                ArchiveSiteReadingType,
+                seed=303,
+                archive_id=1,
+                archive_time=datetime.now(UTC),
+                deleted_time=None,
+                **shared_values,
+            )
+        )
+        await session.commit()
+
+    async with generate_async_session(pg_base_config) as session:
+        await _analyse_reading_type_varied(session, active_test_procedure, [])
+
+    assert active_test_procedure.warnings == {}
+
+
+@pytest.mark.anyio
+async def test_analyse_reading_type_varied_warns_when_uom_changed(pg_base_config):
+    active_test_procedure = _make_active_test_procedure()
+
+    async with generate_async_session(pg_base_config) as session:
+        site = generate_class_instance(Site, seed=101, aggregator_id=1)
+        session.add(site)
+        await session.flush()
+
+        srt = generate_class_instance(SiteReadingType, seed=202, site=site, aggregator_id=1, uom=38)
+        session.add(srt)
+        await session.flush()
+
+        # Archived entry matches srt in every column except uom - the only real variation
+        shared_values = {c.key: getattr(srt, c.key) for c in inspect(SiteReadingType).mapper.column_attrs}
+        shared_values["uom"] = 61
+        session.add(
+            generate_class_instance(
+                ArchiveSiteReadingType,
+                seed=303,
+                archive_id=1,
+                archive_time=datetime.now(UTC),
+                deleted_time=None,
+                **shared_values,
+            )
+        )
+        await session.commit()
+
+    async with generate_async_session(pg_base_config) as session:
+        await _analyse_reading_type_varied(session, active_test_procedure, [])
+
+    assert list(active_test_procedure.warnings.keys()) == ["reading-type.varied"]
+    assert "uom" in active_test_procedure.warnings["reading-type.varied"].message
+
+
+def test_analyse_reading_type_varied_is_registered():
+    assert _analyse_reading_type_varied in POST_TEST_ANALYSERS

--- a/uv.lock
+++ b/uv.lock
@@ -337,7 +337,7 @@ requires-dist = [
     { name = "assertical", marker = "extra == 'test'", specifier = ">=0.4.0" },
     { name = "asyncpg", specifier = ">=0.30.0,<1" },
     { name = "bandit", marker = "extra == 'dev'" },
-    { name = "cactus-schema", git = "https://github.com/bsgip/cactus-schema.git?rev=e5b7003a9d2efef9f226b7b548a56471347af2da" },
+    { name = "cactus-schema", git = "https://github.com/bsgip/cactus-schema.git?rev=9dbe6d2be947fc91bd3a2307cb230665c00b0763" },
     { name = "cactus-test-definitions", specifier = ">=1.15.0,<2" },
     { name = "coverage", marker = "extra == 'dev'" },
     { name = "envoy", git = "https://github.com/bsgip/envoy.git?rev=v1.5.0" },
@@ -366,8 +366,8 @@ provides-extras = ["dev", "test", "docs"]
 
 [[package]]
 name = "cactus-schema"
-version = "1.3.1"
-source = { git = "https://github.com/bsgip/cactus-schema.git?rev=e5b7003a9d2efef9f226b7b548a56471347af2da#e5b7003a9d2efef9f226b7b548a56471347af2da" }
+version = "1.3.2"
+source = { git = "https://github.com/bsgip/cactus-schema.git?rev=9dbe6d2be947fc91bd3a2307cb230665c00b0763#9dbe6d2be947fc91bd3a2307cb230665c00b0763" }
 dependencies = [
     { name = "dataclass-wizard" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -337,7 +337,7 @@ requires-dist = [
     { name = "assertical", marker = "extra == 'test'", specifier = ">=0.4.0" },
     { name = "asyncpg", specifier = ">=0.30.0,<1" },
     { name = "bandit", marker = "extra == 'dev'" },
-    { name = "cactus-schema", git = "https://github.com/bsgip/cactus-schema.git?rev=9dbe6d2be947fc91bd3a2307cb230665c00b0763" },
+    { name = "cactus-schema", git = "https://github.com/bsgip/cactus-schema.git?rev=v1.3.2" },
     { name = "cactus-test-definitions", specifier = ">=1.15.0,<2" },
     { name = "coverage", marker = "extra == 'dev'" },
     { name = "envoy", git = "https://github.com/bsgip/envoy.git?rev=v1.5.0" },
@@ -367,7 +367,7 @@ provides-extras = ["dev", "test", "docs"]
 [[package]]
 name = "cactus-schema"
 version = "1.3.2"
-source = { git = "https://github.com/bsgip/cactus-schema.git?rev=9dbe6d2be947fc91bd3a2307cb230665c00b0763#9dbe6d2be947fc91bd3a2307cb230665c00b0763" }
+source = { git = "https://github.com/bsgip/cactus-schema.git?rev=v1.3.2#9dbe6d2be947fc91bd3a2307cb230665c00b0763" }
 dependencies = [
     { name = "dataclass-wizard" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -337,7 +337,7 @@ requires-dist = [
     { name = "assertical", marker = "extra == 'test'", specifier = ">=0.4.0" },
     { name = "asyncpg", specifier = ">=0.30.0,<1" },
     { name = "bandit", marker = "extra == 'dev'" },
-    { name = "cactus-schema", specifier = ">=1.3.1,<2" },
+    { name = "cactus-schema", git = "https://github.com/bsgip/cactus-schema.git?rev=e5b7003a9d2efef9f226b7b548a56471347af2da" },
     { name = "cactus-test-definitions", specifier = ">=1.15.0,<2" },
     { name = "coverage", marker = "extra == 'dev'" },
     { name = "envoy", git = "https://github.com/bsgip/envoy.git?rev=v1.5.0" },
@@ -367,13 +367,9 @@ provides-extras = ["dev", "test", "docs"]
 [[package]]
 name = "cactus-schema"
 version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/bsgip/cactus-schema.git?rev=e5b7003a9d2efef9f226b7b548a56471347af2da#e5b7003a9d2efef9f226b7b548a56471347af2da" }
 dependencies = [
     { name = "dataclass-wizard" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/db/af9bc63ec020a1669aba261fee962bf11999128abb5b0ad2e586e35f1925/cactus_schema-1.3.1.tar.gz", hash = "sha256:40f791eb25447f82d9e68a2d8fea043330d6b1ac16909a4a93cd313669bbd65b", size = 11284, upload-time = "2026-07-26T23:43:49.112Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/73/689a4f4b29bf2038cb610fb5636833e69903da7caac090eda47fec72202d/cactus_schema-1.3.1-py3-none-any.whl", hash = "sha256:91f54c1a5110a71e0b3d10313e3828f7aa78c0433d295e3c545565d030a865b5", size = 12989, upload-time = "2026-07-26T23:43:47.738Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Allow warnings to be generated. Currently set up as a list of checks to be run after test completion and appended to a list in the runner state. Can be added into existing checks/actions too, and then would be able to show up in the UI during the run. 

Adds a warnings.txt file to the artefact